### PR TITLE
feat: add stable C API and C example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,8 @@ set(
   src/core/livekit_client.cpp
   src/core/room.cpp
 
+  src/capi/livekit.cpp
+
   src/core/detail/audio_device.cpp
   src/core/detail/converted_proto.cpp
   src/core/detail/debouncer.cpp

--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,7 @@ Because webrtc requires C++20.
 - [x] WebSocket signaling and room lifecycle
 - [x] Room and participant state, track publications, active speakers, and quality events
 - [x] Participant metadata, display name, and attribute updates
+- [x] Stable C ABI with opaque handles and callbacks
 - [x] Audio publishing and receiving (signed 16-bit PCM)
 - [x] Video publishing and receiving (I420/VP8)
 - [x] Reliable and lossy data messages
@@ -120,6 +121,13 @@ deterministic; enable it only with `-DBUILD_LEGACY_TEST_TOOLS=ON`.
 
 See the [examples guide](examples/README.md) for build commands, arguments, environment variables,
 and end-to-end audio, video, data-message, and file-transfer verification.
+
+## C API
+
+Pure C applications include `livekit/capi/livekit.h` and link the same `livekitclient` library.
+The API uses opaque handles, caller-owned output buffers, and C function-pointer callbacks; no C++
+type or exception crosses the ABI boundary. See the [`c_sample`](examples/c_sample/sample.c) example
+for room creation, callback registration, connection, string retrieval, and deterministic cleanup.
 
 ## Thanks
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,6 +2,8 @@
 
 add_subdirectory(cpp_sample)
 
+add_subdirectory(c_sample)
+
 add_subdirectory(room_event)
 
 add_subdirectory(publish_audio)

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,6 +48,19 @@ repository configuration.
 
 ## Examples
 
+### `c_sample`
+
+A pure C program using the opaque-handle C API in `livekit/capi/livekit.h`. It registers room,
+participant, and track callbacks, connects, reads the local identity into a caller-owned buffer,
+and cleans up the room and runtime.
+
+```powershell
+& "out/build/vs2022-x64-release/examples/c_sample/Release/c_sample.exe" $url $token
+```
+
+The example source is compiled as C11; only its final link step uses the C++ linker because the SDK
+implementation and libwebrtc are C++ libraries.
+
 ### `cpp_sample`
 
 Connects to a room, prints the local participant identity and SID, and disconnects.

--- a/examples/c_sample/CMakeLists.txt
+++ b/examples/c_sample/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(c_sample sample.c)
+set_target_properties(c_sample PROPERTIES LINKER_LANGUAGE CXX)
+target_compile_features(c_sample PRIVATE c_std_11)
+target_link_libraries(c_sample PRIVATE livekitclient)

--- a/examples/c_sample/sample.c
+++ b/examples/c_sample/sample.c
@@ -1,0 +1,109 @@
+#include "livekit/capi/livekit.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+static void sleep_ms(unsigned milliseconds) { Sleep(milliseconds); }
+#else
+#include <time.h>
+static void sleep_ms(unsigned milliseconds) {
+	struct timespec duration;
+	duration.tv_sec = milliseconds / 1000;
+	duration.tv_nsec = (long)(milliseconds % 1000) * 1000000L;
+	nanosleep(&duration, NULL);
+}
+#endif
+
+static void on_connected(void* user_data, lk_room_t* room) {
+	(void)user_data;
+	(void)room;
+	puts("Connected event received");
+}
+
+static void on_participant_connected(void* user_data, lk_room_t* room,
+                                     const lk_participant_info_t* participant) {
+	(void)user_data;
+	(void)room;
+	printf("Participant connected: %s (%s)\n", participant->identity, participant->sid);
+}
+
+static void on_track_published(void* user_data, lk_room_t* room,
+                               const lk_track_publication_info_t* track,
+                               const lk_participant_info_t* participant) {
+	(void)user_data;
+	(void)room;
+	printf("Track published by %s: %s (%s)\n", participant->identity, track->name, track->sid);
+}
+
+static int read_string(size_t (*getter)(const lk_room_t*, char*, size_t), const lk_room_t* room,
+                       char** output) {
+	const size_t required = getter(room, NULL, 0);
+	if (required == 0) {
+		return 0;
+	}
+	*output = (char*)malloc(required);
+	if (*output == NULL) {
+		return 0;
+	}
+	getter(room, *output, required);
+	return 1;
+}
+
+int main(int argc, char** argv) {
+	const char* url = argc > 1 ? argv[1] : getenv("LIVEKIT_URL");
+	const char* token = argc > 2 ? argv[2] : getenv("LIVEKIT_TOKEN");
+	if (url == NULL || token == NULL || url[0] == '\0' || token[0] == '\0') {
+		fprintf(stderr, "Usage: %s <url> <token>\n", argv[0]);
+		return 2;
+	}
+
+	if (lk_init() != LK_STATUS_OK) {
+		fprintf(stderr, "LiveKit initialization failed: %s\n", lk_last_error());
+		return 1;
+	}
+
+	lk_room_t* room = NULL;
+	if (lk_room_create(&room) != LK_STATUS_OK) {
+		fprintf(stderr, "Room creation failed: %s\n", lk_last_error());
+		lk_shutdown();
+		return 1;
+	}
+
+	lk_room_callbacks_t callbacks;
+	lk_room_callbacks_init(&callbacks);
+	callbacks.on_connected = on_connected;
+	callbacks.on_participant_connected = on_participant_connected;
+	callbacks.on_track_published = on_track_published;
+	lk_room_set_callbacks(room, &callbacks);
+
+	if (lk_room_connect(room, url, token) != LK_STATUS_OK) {
+		fprintf(stderr, "Connection failed: %s\n", lk_last_error());
+		lk_room_destroy(room);
+		lk_shutdown();
+		return 1;
+	}
+
+	for (unsigned attempt = 0; attempt < 100 && !lk_room_is_connected(room); ++attempt) {
+		sleep_ms(100);
+	}
+	if (!lk_room_is_connected(room)) {
+		fprintf(stderr, "Timed out waiting for the RTC connection\n");
+		lk_room_destroy(room);
+		lk_shutdown();
+		return 1;
+	}
+
+	char* identity = NULL;
+	if (read_string(lk_local_participant_identity, room, &identity)) {
+		printf("Connected as %s\n", identity);
+		free(identity);
+	}
+
+	lk_room_disconnect(room);
+	lk_room_destroy(room);
+	lk_shutdown();
+	return 0;
+}

--- a/include/livekit/capi/livekit.h
+++ b/include/livekit/capi/livekit.h
@@ -1,0 +1,285 @@
+#pragma once
+
+#ifndef LKC_CAPI_LIVEKIT_H
+#define LKC_CAPI_LIVEKIT_H
+
+/*
+ * Stable C ABI for the LiveKit C++ client.
+ *
+ * Object pointers are opaque handles owned by the caller. Destroy tracks before their sources.
+ * A published track must remain alive until its room is disconnected. Callback data, strings,
+ * and frame buffers are borrowed and remain valid only for the duration of that callback. A room
+ * must not be destroyed from one of its own callbacks.
+ *
+ * String getters return the required size including the trailing NUL. Pass NULL and zero to query
+ * the size. All functions catch C++ exceptions; details for a failure on the current thread are
+ * available through lk_last_error().
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(_WIN32) && defined(LKC_SHARED)
+#if defined(LKC_BUILDING_LIBRARY)
+#define LKC_API __declspec(dllexport)
+#else
+#define LKC_API __declspec(dllimport)
+#endif
+#else
+#define LKC_API
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct lk_room lk_room_t;
+typedef struct lk_audio_source lk_audio_source_t;
+typedef struct lk_video_source lk_video_source_t;
+typedef struct lk_local_track lk_local_track_t;
+
+typedef enum lk_status {
+	LK_STATUS_OK = 0,
+	LK_STATUS_INVALID_ARGUMENT = 1,
+	LK_STATUS_INVALID_STATE = 2,
+	LK_STATUS_OPERATION_FAILED = 3,
+	LK_STATUS_EXCEPTION = 4
+} lk_status_t;
+
+typedef enum lk_track_kind {
+	LK_TRACK_KIND_UNKNOWN = 0,
+	LK_TRACK_KIND_AUDIO = 1,
+	LK_TRACK_KIND_VIDEO = 2
+} lk_track_kind_t;
+
+typedef enum lk_track_source {
+	LK_TRACK_SOURCE_UNKNOWN = 0,
+	LK_TRACK_SOURCE_CAMERA = 1,
+	LK_TRACK_SOURCE_MICROPHONE = 2,
+	LK_TRACK_SOURCE_SCREEN_SHARE = 3,
+	LK_TRACK_SOURCE_SCREEN_SHARE_AUDIO = 4
+} lk_track_source_t;
+
+typedef enum lk_connection_quality {
+	LK_CONNECTION_QUALITY_UNKNOWN = 0,
+	LK_CONNECTION_QUALITY_POOR = 1,
+	LK_CONNECTION_QUALITY_GOOD = 2,
+	LK_CONNECTION_QUALITY_EXCELLENT = 3,
+	LK_CONNECTION_QUALITY_LOST = 4
+} lk_connection_quality_t;
+
+typedef struct lk_participant_info {
+	const char* sid;
+	const char* identity;
+	const char* name;
+	const char* metadata;
+	float audio_level;
+	lk_connection_quality_t connection_quality;
+	int is_speaking;
+	int is_local;
+} lk_participant_info_t;
+
+typedef struct lk_track_publication_info {
+	const char* sid;
+	const char* name;
+	const char* mime_type;
+	lk_track_kind_t kind;
+	lk_track_source_t source;
+	uint32_t width;
+	uint32_t height;
+	int is_muted;
+	int is_simulcasted;
+} lk_track_publication_info_t;
+
+typedef struct lk_audio_frame {
+	const int16_t* data;
+	size_t sample_count;
+	uint32_t sample_rate;
+	uint32_t num_channels;
+	uint32_t samples_per_channel;
+} lk_audio_frame_t;
+
+typedef struct lk_video_frame {
+	const uint8_t* data;
+	size_t data_size;
+	uint32_t width;
+	uint32_t height;
+	int64_t timestamp_us;
+} lk_video_frame_t;
+
+typedef struct lk_data_received {
+	const uint8_t* data;
+	size_t data_size;
+	const char* topic;
+	const char* participant_identity;
+	int reliable;
+} lk_data_received_t;
+
+typedef struct lk_file_received {
+	const uint8_t* data;
+	size_t data_size;
+	const char* stream_id;
+	const char* name;
+	const char* mime_type;
+	const char* topic;
+	const char* participant_identity;
+} lk_file_received_t;
+
+typedef struct lk_attribute {
+	const char* key;
+	const char* value;
+} lk_attribute_t;
+
+typedef void (*lk_room_event_callback)(void* user_data, lk_room_t* room);
+typedef void (*lk_participant_event_callback)(void* user_data, lk_room_t* room,
+                                              const lk_participant_info_t* participant);
+typedef void (*lk_track_event_callback)(void* user_data, lk_room_t* room,
+                                        const lk_track_publication_info_t* track,
+                                        const lk_participant_info_t* participant);
+typedef void (*lk_audio_frame_callback)(void* user_data, lk_room_t* room,
+                                        const lk_track_publication_info_t* track,
+                                        const lk_participant_info_t* participant,
+                                        const lk_audio_frame_t* frame);
+typedef void (*lk_video_frame_callback)(void* user_data, lk_room_t* room,
+                                        const lk_track_publication_info_t* track,
+                                        const lk_participant_info_t* participant,
+                                        const lk_video_frame_t* frame);
+typedef void (*lk_data_received_callback)(void* user_data, lk_room_t* room,
+                                          const lk_data_received_t* event);
+typedef void (*lk_file_received_callback)(void* user_data, lk_room_t* room,
+                                          const lk_file_received_t* event);
+typedef void (*lk_room_metadata_callback)(void* user_data, lk_room_t* room, const char* metadata);
+typedef void (*lk_connection_quality_callback)(void* user_data, lk_room_t* room,
+                                               lk_connection_quality_t quality,
+                                               const lk_participant_info_t* participant);
+typedef void (*lk_active_speakers_callback)(void* user_data, lk_room_t* room,
+                                            const lk_participant_info_t* participants,
+                                            size_t participant_count);
+
+typedef struct lk_room_callbacks {
+	size_t struct_size;
+	void* user_data;
+	lk_room_event_callback on_connected;
+	lk_room_event_callback on_disconnected;
+	lk_participant_event_callback on_participant_connected;
+	lk_participant_event_callback on_participant_disconnected;
+	lk_track_event_callback on_track_published;
+	lk_track_event_callback on_track_unpublished;
+	lk_track_event_callback on_track_muted;
+	lk_track_event_callback on_track_unmuted;
+	lk_track_event_callback on_track_subscribed;
+	lk_audio_frame_callback on_audio_frame;
+	lk_video_frame_callback on_video_frame;
+	lk_data_received_callback on_data_received;
+	lk_file_received_callback on_file_received;
+	lk_room_metadata_callback on_room_metadata_changed;
+	lk_connection_quality_callback on_connection_quality_changed;
+	lk_active_speakers_callback on_active_speakers_changed;
+} lk_room_callbacks_t;
+
+typedef struct lk_audio_source_options {
+	size_t struct_size;
+	uint32_t sample_rate;
+	uint32_t num_channels;
+	uint32_t queue_size_ms;
+	int echo_cancellation;
+	int auto_gain_control;
+	int noise_suppression;
+} lk_audio_source_options_t;
+
+typedef struct lk_video_source_options {
+	size_t struct_size;
+	int is_screencast;
+} lk_video_source_options_t;
+
+typedef struct lk_track_publish_options {
+	size_t struct_size;
+	lk_track_source_t source;
+	int dtx;
+	int red;
+	int simulcast;
+	const char* stream;
+} lk_track_publish_options_t;
+
+typedef struct lk_data_publish_options {
+	size_t struct_size;
+	int reliable;
+	const char* topic;
+	const char* const* destination_identities;
+	size_t destination_identity_count;
+} lk_data_publish_options_t;
+
+typedef struct lk_file_send_options {
+	size_t struct_size;
+	const char* topic;
+	const char* mime_type;
+	const char* const* destination_identities;
+	size_t destination_identity_count;
+	size_t chunk_size;
+} lk_file_send_options_t;
+
+LKC_API lk_status_t lk_init(void);
+LKC_API lk_status_t lk_shutdown(void);
+LKC_API size_t lk_version(char* buffer, size_t buffer_size);
+LKC_API const char* lk_last_error(void);
+
+LKC_API void lk_room_callbacks_init(lk_room_callbacks_t* callbacks);
+LKC_API void lk_audio_source_options_init(lk_audio_source_options_t* options);
+LKC_API void lk_video_source_options_init(lk_video_source_options_t* options);
+LKC_API void lk_track_publish_options_init(lk_track_publish_options_t* options);
+LKC_API void lk_data_publish_options_init(lk_data_publish_options_t* options);
+LKC_API void lk_file_send_options_init(lk_file_send_options_t* options);
+
+LKC_API lk_status_t lk_room_create(lk_room_t** room);
+LKC_API void lk_room_destroy(lk_room_t* room);
+LKC_API lk_status_t lk_room_set_callbacks(lk_room_t* room, const lk_room_callbacks_t* callbacks);
+LKC_API lk_status_t lk_room_connect(lk_room_t* room, const char* url, const char* token);
+LKC_API lk_status_t lk_room_disconnect(lk_room_t* room);
+LKC_API int lk_room_is_connected(const lk_room_t* room);
+LKC_API size_t lk_room_sid(const lk_room_t* room, char* buffer, size_t buffer_size);
+LKC_API size_t lk_room_name(const lk_room_t* room, char* buffer, size_t buffer_size);
+LKC_API size_t lk_room_metadata(const lk_room_t* room, char* buffer, size_t buffer_size);
+LKC_API int lk_room_is_recording(const lk_room_t* room);
+
+LKC_API size_t lk_local_participant_sid(const lk_room_t* room, char* buffer, size_t buffer_size);
+LKC_API size_t lk_local_participant_identity(const lk_room_t* room, char* buffer,
+                                             size_t buffer_size);
+LKC_API size_t lk_local_participant_name(const lk_room_t* room, char* buffer, size_t buffer_size);
+LKC_API size_t lk_local_participant_metadata(const lk_room_t* room, char* buffer,
+                                             size_t buffer_size);
+LKC_API lk_status_t lk_local_participant_set_metadata(lk_room_t* room, const char* metadata);
+LKC_API lk_status_t lk_local_participant_set_name(lk_room_t* room, const char* name);
+LKC_API lk_status_t lk_local_participant_set_attributes(lk_room_t* room,
+                                                        const lk_attribute_t* attributes,
+                                                        size_t attribute_count);
+
+LKC_API lk_status_t lk_audio_source_create(const lk_audio_source_options_t* options,
+                                           lk_audio_source_t** source);
+LKC_API lk_status_t lk_audio_source_destroy(lk_audio_source_t* source);
+LKC_API lk_status_t lk_audio_source_capture_frame(lk_audio_source_t* source, const int16_t* data,
+                                                  uint32_t samples_per_channel);
+LKC_API lk_status_t lk_video_source_create(const lk_video_source_options_t* options,
+                                           lk_video_source_t** source);
+LKC_API lk_status_t lk_video_source_destroy(lk_video_source_t* source);
+LKC_API lk_status_t lk_video_source_capture_i420(lk_video_source_t* source, const uint8_t* data,
+                                                 size_t data_size, uint32_t width, uint32_t height,
+                                                 int64_t timestamp_us);
+
+LKC_API lk_status_t lk_room_create_audio_track(lk_room_t* room, const char* label,
+                                               lk_audio_source_t* source, lk_local_track_t** track);
+LKC_API lk_status_t lk_room_create_video_track(lk_room_t* room, const char* label,
+                                               lk_video_source_t* source, lk_local_track_t** track);
+LKC_API lk_status_t lk_local_track_publish(lk_room_t* room, lk_local_track_t* track,
+                                           const lk_track_publish_options_t* options);
+LKC_API lk_status_t lk_local_track_destroy(lk_local_track_t* track);
+
+LKC_API lk_status_t lk_room_publish_data(lk_room_t* room, const uint8_t* data, size_t data_size,
+                                         const lk_data_publish_options_t* options);
+LKC_API lk_status_t lk_room_send_file(lk_room_t* room, const char* path,
+                                      const lk_file_send_options_t* options);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/capi/livekit.cpp
+++ b/src/capi/livekit.cpp
@@ -1,0 +1,1061 @@
+#include "livekit/capi/livekit.h"
+
+#include "livekit/core/livekit_client.h"
+#include "livekit/core/track/audio_source_interface.h"
+#include "livekit/core/track/local_track_interface.h"
+#include "livekit/core/track/remote_track_interface.h"
+#include "livekit/core/track/video_source_interface.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <exception>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace core = livekit::core;
+
+class CRoomEvents;
+
+struct RoomHandleState {
+	std::atomic_bool alive{true};
+	std::atomic_bool connected{false};
+};
+
+struct lk_room {
+	std::unique_ptr<core::RoomInterface> room;
+	std::unique_ptr<CRoomEvents> events;
+	std::mutex callbacks_mutex;
+	std::mutex callback_lifetime_mutex;
+	lk_room_callbacks_t callbacks{};
+	std::shared_ptr<RoomHandleState> state = std::make_shared<RoomHandleState>();
+};
+
+struct lk_audio_source {
+	std::unique_ptr<core::AudioSourceInterface> source;
+	std::atomic_size_t track_references{0};
+	uint32_t sample_rate = 0;
+	uint32_t num_channels = 0;
+};
+
+struct lk_video_source {
+	std::unique_ptr<core::VideoSourceInterface> source;
+	std::atomic_size_t track_references{0};
+};
+
+struct lk_local_track {
+	std::unique_ptr<core::LocalTrackInterface> track;
+	lk_room_t* owner = nullptr;
+	lk_audio_source_t* audio_source = nullptr;
+	lk_video_source_t* video_source = nullptr;
+	std::shared_ptr<RoomHandleState> room_state;
+	bool published = false;
+};
+
+namespace {
+
+thread_local std::string last_error;
+
+void SetError(std::string error) { last_error = std::move(error); }
+
+lk_status_t Failure(lk_status_t status, const char* message) {
+	SetError(message);
+	return status;
+}
+
+template <typename Function> lk_status_t Guard(Function&& function) noexcept {
+	try {
+		last_error.clear();
+		return function();
+	} catch (const std::exception& exception) {
+		SetError(exception.what());
+		return LK_STATUS_EXCEPTION;
+	} catch (...) {
+		SetError("unknown C++ exception");
+		return LK_STATUS_EXCEPTION;
+	}
+}
+
+template <typename Function> size_t SizeGuard(Function&& function) noexcept {
+	try {
+		last_error.clear();
+		return function();
+	} catch (const std::exception& exception) {
+		SetError(exception.what());
+		return 0;
+	} catch (...) {
+		SetError("unknown C++ exception");
+		return 0;
+	}
+}
+
+size_t CopyString(const std::string& value, char* buffer, size_t buffer_size) noexcept {
+	const size_t required = value.size() + 1;
+	if (buffer != nullptr && buffer_size != 0) {
+		const size_t count = std::min(value.size(), buffer_size - 1);
+		std::memcpy(buffer, value.data(), count);
+		buffer[count] = '\0';
+	}
+	return required;
+}
+
+bool HasField(size_t struct_size, size_t offset, size_t field_size) {
+	return struct_size >= offset + field_size;
+}
+
+#define LKC_HAS_FIELD(value, type, field)                                                          \
+	HasField((value)->struct_size, offsetof(type, field), sizeof((value)->field))
+
+core::TrackSource ToCoreTrackSource(lk_track_source_t source) {
+	switch (source) {
+	case LK_TRACK_SOURCE_CAMERA:
+		return core::TrackSource::Camera;
+	case LK_TRACK_SOURCE_MICROPHONE:
+		return core::TrackSource::Microphone;
+	case LK_TRACK_SOURCE_SCREEN_SHARE:
+		return core::TrackSource::ScreenShare;
+	case LK_TRACK_SOURCE_SCREEN_SHARE_AUDIO:
+		return core::TrackSource::ScreenShareAudio;
+	default:
+		return core::TrackSource::Unknown;
+	}
+}
+
+lk_track_kind_t ToCTrackKind(core::TrackKind kind) {
+	switch (kind) {
+	case core::TrackKind::Audio:
+		return LK_TRACK_KIND_AUDIO;
+	case core::TrackKind::Video:
+		return LK_TRACK_KIND_VIDEO;
+	default:
+		return LK_TRACK_KIND_UNKNOWN;
+	}
+}
+
+lk_track_source_t ToCTrackSource(core::TrackSource source) {
+	switch (source) {
+	case core::TrackSource::Camera:
+		return LK_TRACK_SOURCE_CAMERA;
+	case core::TrackSource::Microphone:
+		return LK_TRACK_SOURCE_MICROPHONE;
+	case core::TrackSource::ScreenShare:
+		return LK_TRACK_SOURCE_SCREEN_SHARE;
+	case core::TrackSource::ScreenShareAudio:
+		return LK_TRACK_SOURCE_SCREEN_SHARE_AUDIO;
+	default:
+		return LK_TRACK_SOURCE_UNKNOWN;
+	}
+}
+
+lk_connection_quality_t ToCConnectionQuality(core::ConnectionQuality quality) {
+	switch (quality) {
+	case core::ConnectionQuality::Poor:
+		return LK_CONNECTION_QUALITY_POOR;
+	case core::ConnectionQuality::Good:
+		return LK_CONNECTION_QUALITY_GOOD;
+	case core::ConnectionQuality::Excellent:
+		return LK_CONNECTION_QUALITY_EXCELLENT;
+	case core::ConnectionQuality::Lost:
+		return LK_CONNECTION_QUALITY_LOST;
+	default:
+		return LK_CONNECTION_QUALITY_UNKNOWN;
+	}
+}
+
+struct OwnedParticipantInfo {
+	explicit OwnedParticipantInfo(core::ParticipantInterface* participant) {
+		if (participant == nullptr) {
+			return;
+		}
+		sid = participant->Sid();
+		identity = participant->Identity();
+		name = participant->Name();
+		metadata = participant->Metadata();
+		info = {sid.c_str(),
+		        identity.c_str(),
+		        name.c_str(),
+		        metadata.c_str(),
+		        participant->AudioLevel(),
+		        ToCConnectionQuality(participant->GetConnectionQuality()),
+		        participant->IsSpeaking() ? 1 : 0,
+		        participant->IsLocalParticipant() ? 1 : 0};
+	}
+
+	std::string sid;
+	std::string identity;
+	std::string name;
+	std::string metadata;
+	lk_participant_info_t info{};
+};
+
+struct OwnedTrackInfo {
+	explicit OwnedTrackInfo(core::TrackPublicationInterface* publication) {
+		if (publication == nullptr) {
+			return;
+		}
+		sid = publication->Sid();
+		name = publication->Name();
+		mime_type = publication->MimeType();
+		const auto dimensions = publication->Dimensions();
+		info = {sid.c_str(),
+		        name.c_str(),
+		        mime_type.c_str(),
+		        ToCTrackKind(publication->Kind()),
+		        ToCTrackSource(publication->Source()),
+		        dimensions.width,
+		        dimensions.height,
+		        publication->IsMuted() ? 1 : 0,
+		        publication->IsSimulcasted() ? 1 : 0};
+	}
+
+	OwnedTrackInfo(core::RemoteTrackInterface* track,
+	               core::RemoteParticipantInterface* participant) {
+		core::TrackPublicationInterface* publication = nullptr;
+		if (track != nullptr && participant != nullptr) {
+			for (auto* candidate : participant->GetTrackPublications()) {
+				if (candidate->Sid() == track->Sid()) {
+					publication = candidate;
+					break;
+				}
+			}
+		}
+		if (publication != nullptr) {
+			sid = publication->Sid();
+			name = publication->Name();
+			mime_type = publication->MimeType();
+			const auto dimensions = publication->Dimensions();
+			info = {sid.c_str(),
+			        name.c_str(),
+			        mime_type.c_str(),
+			        ToCTrackKind(publication->Kind()),
+			        ToCTrackSource(publication->Source()),
+			        dimensions.width,
+			        dimensions.height,
+			        publication->IsMuted() ? 1 : 0,
+			        publication->IsSimulcasted() ? 1 : 0};
+			return;
+		}
+		if (track == nullptr) {
+			return;
+		}
+		sid = track->Sid();
+		name = track->Name();
+		const auto dimensions = track->Dimensions();
+		info = {sid.c_str(),
+		        name.c_str(),
+		        "",
+		        ToCTrackKind(track->Kind()),
+		        ToCTrackSource(track->Source()),
+		        dimensions.width,
+		        dimensions.height,
+		        0,
+		        0};
+	}
+
+	std::string sid;
+	std::string name;
+	std::string mime_type;
+	lk_track_publication_info_t info{};
+};
+
+core::LocalParticipantInterface* LocalParticipant(lk_room_t* room) {
+	return room != nullptr && room->room != nullptr ? room->room->GetLocalParticipant() : nullptr;
+}
+
+core::LocalParticipantInterface* LocalParticipant(const lk_room_t* room) {
+	return room != nullptr && room->room != nullptr ? room->room->GetLocalParticipant() : nullptr;
+}
+
+template <typename Function> void InvokeRoomCallback(lk_room_t* owner, Function&& function) {
+	if (owner == nullptr) {
+		return;
+	}
+	std::lock_guard<std::mutex> lifetime_guard(owner->callback_lifetime_mutex);
+	lk_room_callbacks_t callbacks{};
+	{
+		std::lock_guard<std::mutex> guard(owner->callbacks_mutex);
+		callbacks = owner->callbacks;
+	}
+	function(callbacks);
+}
+
+std::vector<std::string> DestinationIdentities(const char* const* identities, size_t count) {
+	std::vector<std::string> result;
+	result.reserve(count);
+	for (size_t index = 0; index < count; ++index) {
+		if (identities[index] != nullptr) {
+			result.emplace_back(identities[index]);
+		}
+	}
+	return result;
+}
+
+} // namespace
+
+class CRoomEvents final : public core::RoomEventInterface {
+public:
+	explicit CRoomEvents(lk_room_t* owner) : owner_(owner) {}
+
+	void OnConnected() override {
+		InvokeRoomCallback(owner_, [this](const lk_room_callbacks_t& callbacks) {
+			if (callbacks.on_connected != nullptr) {
+				callbacks.on_connected(callbacks.user_data, owner_);
+			}
+		});
+	}
+
+	void OnDisconnected() override {
+		owner_->state->connected.store(false);
+		InvokeRoomCallback(owner_, [this](const lk_room_callbacks_t& callbacks) {
+			if (callbacks.on_disconnected != nullptr) {
+				callbacks.on_disconnected(callbacks.user_data, owner_);
+			}
+		});
+	}
+
+	void OnParticipantConnected(core::RemoteParticipantInterface* participant) override {
+		Participant(callbacks_member(&lk_room_callbacks_t::on_participant_connected), participant);
+	}
+
+	void OnParticipantDisconnected(core::RemoteParticipantInterface* participant) override {
+		Participant(callbacks_member(&lk_room_callbacks_t::on_participant_disconnected),
+		            participant);
+	}
+
+	void OnTrackPublished(core::TrackPublicationInterface* track,
+	                      core::RemoteParticipantInterface* participant) override {
+		Track(callbacks_member(&lk_room_callbacks_t::on_track_published), track, participant);
+	}
+
+	void OnTrackUnpublished(core::TrackPublicationInterface* track,
+	                        core::RemoteParticipantInterface* participant) override {
+		Track(callbacks_member(&lk_room_callbacks_t::on_track_unpublished), track, participant);
+	}
+
+	void OnTrackMuted(core::TrackPublicationInterface* track,
+	                  core::ParticipantInterface* participant) override {
+		Track(callbacks_member(&lk_room_callbacks_t::on_track_muted), track, participant);
+	}
+
+	void OnTrackUnmuted(core::TrackPublicationInterface* track,
+	                    core::ParticipantInterface* participant) override {
+		Track(callbacks_member(&lk_room_callbacks_t::on_track_unmuted), track, participant);
+	}
+
+	void OnTrackSubscribed(core::RemoteTrackInterface* track,
+	                       core::RemoteParticipantInterface* participant) override {
+		OwnedTrackInfo owned_track(track, participant);
+		OwnedParticipantInfo owned_participant(participant);
+		InvokeRoomCallback(owner_, [&](const lk_room_callbacks_t& callbacks) {
+			if (callbacks.on_track_subscribed != nullptr) {
+				callbacks.on_track_subscribed(callbacks.user_data, owner_, &owned_track.info,
+				                              &owned_participant.info);
+			}
+		});
+	}
+
+	void OnAudioFrame(core::RemoteTrackInterface* track,
+	                  core::RemoteParticipantInterface* participant,
+	                  const core::AudioFrame& frame) override {
+		OwnedTrackInfo owned_track(track, participant);
+		OwnedParticipantInfo owned_participant(participant);
+		const lk_audio_frame_t c_frame{frame.data.data(), frame.data.size(), frame.sample_rate,
+		                               frame.num_channels, frame.samples_per_channel};
+		InvokeRoomCallback(owner_, [&](const lk_room_callbacks_t& callbacks) {
+			if (callbacks.on_audio_frame != nullptr) {
+				callbacks.on_audio_frame(callbacks.user_data, owner_, &owned_track.info,
+				                         &owned_participant.info, &c_frame);
+			}
+		});
+	}
+
+	void OnVideoFrame(core::RemoteTrackInterface* track,
+	                  core::RemoteParticipantInterface* participant,
+	                  const core::VideoFrame& frame) override {
+		OwnedTrackInfo owned_track(track, participant);
+		OwnedParticipantInfo owned_participant(participant);
+		const lk_video_frame_t c_frame{frame.data.data(), frame.data.size(), frame.width,
+		                               frame.height, frame.timestamp_us};
+		InvokeRoomCallback(owner_, [&](const lk_room_callbacks_t& callbacks) {
+			if (callbacks.on_video_frame != nullptr) {
+				callbacks.on_video_frame(callbacks.user_data, owner_, &owned_track.info,
+				                         &owned_participant.info, &c_frame);
+			}
+		});
+	}
+
+	void OnDataReceived(const core::DataReceivedEvent& event) override {
+		const lk_data_received_t c_event{event.payload.data(), event.payload.size(),
+		                                 event.topic.c_str(), event.participant_identity.c_str(),
+		                                 event.reliable ? 1 : 0};
+		InvokeRoomCallback(owner_, [&](const lk_room_callbacks_t& callbacks) {
+			if (callbacks.on_data_received != nullptr) {
+				callbacks.on_data_received(callbacks.user_data, owner_, &c_event);
+			}
+		});
+	}
+
+	void OnFileReceived(const core::FileReceivedEvent& event) override {
+		const lk_file_received_t c_event{event.data.data(),
+		                                 event.data.size(),
+		                                 event.stream_id.c_str(),
+		                                 event.name.c_str(),
+		                                 event.mime_type.c_str(),
+		                                 event.topic.c_str(),
+		                                 event.participant_identity.c_str()};
+		InvokeRoomCallback(owner_, [&](const lk_room_callbacks_t& callbacks) {
+			if (callbacks.on_file_received != nullptr) {
+				callbacks.on_file_received(callbacks.user_data, owner_, &c_event);
+			}
+		});
+	}
+
+	void OnRoomMetadataChanged(const std::string& metadata) override {
+		InvokeRoomCallback(owner_, [&](const lk_room_callbacks_t& callbacks) {
+			if (callbacks.on_room_metadata_changed != nullptr) {
+				callbacks.on_room_metadata_changed(callbacks.user_data, owner_, metadata.c_str());
+			}
+		});
+	}
+
+	void OnConnectionQualityChanged(core::ConnectionQuality quality,
+	                                core::ParticipantInterface* participant) override {
+		OwnedParticipantInfo owned_participant(participant);
+		InvokeRoomCallback(owner_, [&](const lk_room_callbacks_t& callbacks) {
+			if (callbacks.on_connection_quality_changed != nullptr) {
+				callbacks.on_connection_quality_changed(callbacks.user_data, owner_,
+				                                        ToCConnectionQuality(quality),
+				                                        &owned_participant.info);
+			}
+		});
+	}
+
+	void
+	OnActiveSpeakersChanged(const std::vector<core::ParticipantInterface*>& participants) override {
+		std::vector<OwnedParticipantInfo> owned;
+		owned.reserve(participants.size());
+		for (auto* participant : participants) {
+			owned.emplace_back(participant);
+		}
+		std::vector<lk_participant_info_t> infos;
+		infos.reserve(owned.size());
+		for (const auto& participant : owned) {
+			infos.push_back(participant.info);
+		}
+		InvokeRoomCallback(owner_, [&](const lk_room_callbacks_t& callbacks) {
+			if (callbacks.on_active_speakers_changed != nullptr) {
+				callbacks.on_active_speakers_changed(callbacks.user_data, owner_, infos.data(),
+				                                     infos.size());
+			}
+		});
+	}
+
+private:
+	template <typename Member> static Member callbacks_member(Member member) { return member; }
+
+	void Participant(lk_participant_event_callback lk_room_callbacks_t::*callback,
+	                 core::ParticipantInterface* participant) {
+		OwnedParticipantInfo owned(participant);
+		InvokeRoomCallback(owner_, [&](const lk_room_callbacks_t& callbacks) {
+			if (callbacks.*callback != nullptr) {
+				(callbacks.*callback)(callbacks.user_data, owner_, &owned.info);
+			}
+		});
+	}
+
+	void Track(lk_track_event_callback lk_room_callbacks_t::*callback,
+	           core::TrackPublicationInterface* track, core::ParticipantInterface* participant) {
+		OwnedTrackInfo owned_track(track);
+		OwnedParticipantInfo owned_participant(participant);
+		InvokeRoomCallback(owner_, [&](const lk_room_callbacks_t& callbacks) {
+			if (callbacks.*callback != nullptr) {
+				(callbacks.*callback)(callbacks.user_data, owner_, &owned_track.info,
+				                      &owned_participant.info);
+			}
+		});
+	}
+
+	lk_room_t* owner_;
+};
+
+extern "C" {
+
+lk_status_t lk_init(void) {
+	return Guard([] { return core::Init() ? LK_STATUS_OK : LK_STATUS_OPERATION_FAILED; });
+}
+
+lk_status_t lk_shutdown(void) {
+	return Guard([] { return core::Destroy() ? LK_STATUS_OK : LK_STATUS_OPERATION_FAILED; });
+}
+
+size_t lk_version(char* buffer, size_t buffer_size) {
+	try {
+		last_error.clear();
+		return CopyString(core::Version(), buffer, buffer_size);
+	} catch (const std::exception& exception) {
+		SetError(exception.what());
+		return 0;
+	} catch (...) {
+		SetError("unknown C++ exception");
+		return 0;
+	}
+}
+
+const char* lk_last_error(void) { return last_error.c_str(); }
+
+void lk_room_callbacks_init(lk_room_callbacks_t* callbacks) {
+	if (callbacks != nullptr) {
+		*callbacks = {};
+		callbacks->struct_size = sizeof(*callbacks);
+	}
+}
+
+void lk_audio_source_options_init(lk_audio_source_options_t* options) {
+	if (options != nullptr) {
+		*options = {};
+		options->struct_size = sizeof(*options);
+		options->sample_rate = 48000;
+		options->num_channels = 1;
+		options->queue_size_ms = 200;
+	}
+}
+
+void lk_video_source_options_init(lk_video_source_options_t* options) {
+	if (options != nullptr) {
+		*options = {};
+		options->struct_size = sizeof(*options);
+	}
+}
+
+void lk_track_publish_options_init(lk_track_publish_options_t* options) {
+	if (options != nullptr) {
+		*options = {};
+		options->struct_size = sizeof(*options);
+		options->dtx = 1;
+		options->red = 1;
+		options->simulcast = 1;
+	}
+}
+
+void lk_data_publish_options_init(lk_data_publish_options_t* options) {
+	if (options != nullptr) {
+		*options = {};
+		options->struct_size = sizeof(*options);
+		options->reliable = 1;
+	}
+}
+
+void lk_file_send_options_init(lk_file_send_options_t* options) {
+	if (options != nullptr) {
+		*options = {};
+		options->struct_size = sizeof(*options);
+		options->topic = "files";
+		options->mime_type = "application/octet-stream";
+		options->chunk_size = 15000;
+	}
+}
+
+lk_status_t lk_room_create(lk_room_t** room) {
+	return Guard([&] {
+		if (room == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "room output is null");
+		}
+		*room = nullptr;
+		auto result = std::make_unique<lk_room_t>();
+		result->room = core::CreateRoomUnique();
+		if (!result->room) {
+			return Failure(LK_STATUS_OPERATION_FAILED, "failed to create room");
+		}
+		result->events = std::make_unique<CRoomEvents>(result.get());
+		result->room->AddEventListener(result->events.get());
+		*room = result.release();
+		return LK_STATUS_OK;
+	});
+}
+
+void lk_room_destroy(lk_room_t* room) {
+	if (room == nullptr) {
+		return;
+	}
+	try {
+		room->room->RemoveEventListener();
+		if (room->room->IsConnected()) {
+			room->room->Disconnect();
+		}
+		room->state->connected.store(false);
+		room->state->alive.store(false);
+		{ std::lock_guard<std::mutex> guard(room->callback_lifetime_mutex); }
+		delete room;
+	} catch (...) {
+		SetError("exception while destroying room");
+	}
+}
+
+lk_status_t lk_room_set_callbacks(lk_room_t* room, const lk_room_callbacks_t* callbacks) {
+	return Guard([&] {
+		if (room == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "room is null");
+		}
+		lk_room_callbacks_t copy{};
+		if (callbacks != nullptr) {
+			if (callbacks->struct_size < sizeof(callbacks->struct_size)) {
+				return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid callbacks struct size");
+			}
+			std::memcpy(&copy, callbacks, std::min(callbacks->struct_size, sizeof(copy)));
+			copy.struct_size = sizeof(copy);
+		}
+		std::lock_guard<std::mutex> guard(room->callbacks_mutex);
+		room->callbacks = copy;
+		return LK_STATUS_OK;
+	});
+}
+
+lk_status_t lk_room_connect(lk_room_t* room, const char* url, const char* token) {
+	return Guard([&] {
+		if (room == nullptr || url == nullptr || token == nullptr || *url == '\0' ||
+		    *token == '\0') {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "room, URL, and token are required");
+		}
+		if (!room->room->Connect(url, token)) {
+			return Failure(LK_STATUS_OPERATION_FAILED, "failed to connect room");
+		}
+		room->state->connected.store(true);
+		return LK_STATUS_OK;
+	});
+}
+
+lk_status_t lk_room_disconnect(lk_room_t* room) {
+	return Guard([&] {
+		if (room == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "room is null");
+		}
+		if (!room->room->Disconnect()) {
+			return Failure(LK_STATUS_INVALID_STATE, "room is already disconnected");
+		}
+		room->state->connected.store(false);
+		return LK_STATUS_OK;
+	});
+}
+
+int lk_room_is_connected(const lk_room_t* room) {
+	return room != nullptr && room->room != nullptr && room->room->IsConnected() ? 1 : 0;
+}
+
+size_t lk_room_sid(const lk_room_t* room, char* buffer, size_t buffer_size) {
+	return SizeGuard(
+	    [&] { return room != nullptr ? CopyString(room->room->Sid(), buffer, buffer_size) : 0; });
+}
+
+size_t lk_room_name(const lk_room_t* room, char* buffer, size_t buffer_size) {
+	return SizeGuard(
+	    [&] { return room != nullptr ? CopyString(room->room->Name(), buffer, buffer_size) : 0; });
+}
+
+size_t lk_room_metadata(const lk_room_t* room, char* buffer, size_t buffer_size) {
+	return SizeGuard([&] {
+		return room != nullptr ? CopyString(room->room->Metadata(), buffer, buffer_size) : 0;
+	});
+}
+
+int lk_room_is_recording(const lk_room_t* room) {
+	return room != nullptr && room->room->IsRecording() ? 1 : 0;
+}
+
+size_t lk_local_participant_sid(const lk_room_t* room, char* buffer, size_t buffer_size) {
+	return SizeGuard([&] {
+		auto* participant = LocalParticipant(room);
+		return participant != nullptr ? CopyString(participant->Sid(), buffer, buffer_size) : 0;
+	});
+}
+
+size_t lk_local_participant_identity(const lk_room_t* room, char* buffer, size_t buffer_size) {
+	return SizeGuard([&] {
+		auto* participant = LocalParticipant(room);
+		return participant != nullptr ? CopyString(participant->Identity(), buffer, buffer_size)
+		                              : 0;
+	});
+}
+
+size_t lk_local_participant_name(const lk_room_t* room, char* buffer, size_t buffer_size) {
+	return SizeGuard([&] {
+		auto* participant = LocalParticipant(room);
+		return participant != nullptr ? CopyString(participant->Name(), buffer, buffer_size) : 0;
+	});
+}
+
+size_t lk_local_participant_metadata(const lk_room_t* room, char* buffer, size_t buffer_size) {
+	return SizeGuard([&] {
+		auto* participant = LocalParticipant(room);
+		return participant != nullptr ? CopyString(participant->Metadata(), buffer, buffer_size)
+		                              : 0;
+	});
+}
+
+lk_status_t lk_local_participant_set_metadata(lk_room_t* room, const char* metadata) {
+	return Guard([&] {
+		auto* participant = LocalParticipant(room);
+		if (participant == nullptr || metadata == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "room and metadata are required");
+		}
+		return participant->SetMetadata(metadata)
+		           ? LK_STATUS_OK
+		           : Failure(LK_STATUS_OPERATION_FAILED, "failed to update metadata");
+	});
+}
+
+lk_status_t lk_local_participant_set_name(lk_room_t* room, const char* name) {
+	return Guard([&] {
+		auto* participant = LocalParticipant(room);
+		if (participant == nullptr || name == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "room and name are required");
+		}
+		return participant->SetName(name)
+		           ? LK_STATUS_OK
+		           : Failure(LK_STATUS_OPERATION_FAILED, "failed to update name");
+	});
+}
+
+lk_status_t lk_local_participant_set_attributes(lk_room_t* room, const lk_attribute_t* attributes,
+                                                size_t attribute_count) {
+	return Guard([&] {
+		auto* participant = LocalParticipant(room);
+		if (participant == nullptr || (attributes == nullptr && attribute_count != 0)) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid room or attributes");
+		}
+		std::map<std::string, std::string> values;
+		for (size_t index = 0; index < attribute_count; ++index) {
+			if (attributes[index].key == nullptr || attributes[index].value == nullptr) {
+				return Failure(LK_STATUS_INVALID_ARGUMENT, "attribute key or value is null");
+			}
+			values[attributes[index].key] = attributes[index].value;
+		}
+		return participant->SetAttributes(values)
+		           ? LK_STATUS_OK
+		           : Failure(LK_STATUS_OPERATION_FAILED, "failed to update attributes");
+	});
+}
+
+lk_status_t lk_audio_source_create(const lk_audio_source_options_t* options,
+                                   lk_audio_source_t** source) {
+	return Guard([&] {
+		if (source == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "source output is null");
+		}
+		*source = nullptr;
+		lk_audio_source_options_t values;
+		lk_audio_source_options_init(&values);
+		if (options != nullptr) {
+			if (options->struct_size < sizeof(options->struct_size)) {
+				return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid audio options struct size");
+			}
+			if (LKC_HAS_FIELD(options, lk_audio_source_options_t, sample_rate)) {
+				values.sample_rate = options->sample_rate;
+			}
+			if (LKC_HAS_FIELD(options, lk_audio_source_options_t, num_channels)) {
+				values.num_channels = options->num_channels;
+			}
+			if (LKC_HAS_FIELD(options, lk_audio_source_options_t, queue_size_ms)) {
+				values.queue_size_ms = options->queue_size_ms;
+			}
+			if (LKC_HAS_FIELD(options, lk_audio_source_options_t, echo_cancellation)) {
+				values.echo_cancellation = options->echo_cancellation;
+			}
+			if (LKC_HAS_FIELD(options, lk_audio_source_options_t, auto_gain_control)) {
+				values.auto_gain_control = options->auto_gain_control;
+			}
+			if (LKC_HAS_FIELD(options, lk_audio_source_options_t, noise_suppression)) {
+				values.noise_suppression = options->noise_suppression;
+			}
+		}
+		if (values.sample_rate == 0 || values.num_channels == 0 || values.queue_size_ms == 0) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid audio source dimensions");
+		}
+		core::AudioSourceOptions core_options;
+		core_options.echo_cancellation = values.echo_cancellation != 0;
+		core_options.auto_gain_control = values.auto_gain_control != 0;
+		core_options.noise_suppression = values.noise_suppression != 0;
+		auto result = std::make_unique<lk_audio_source_t>();
+		result->source.reset(core::CreateAudioSource(core_options, values.sample_rate,
+		                                             values.num_channels, values.queue_size_ms));
+		if (!result->source) {
+			return Failure(LK_STATUS_OPERATION_FAILED, "failed to create audio source");
+		}
+		result->sample_rate = values.sample_rate;
+		result->num_channels = values.num_channels;
+		*source = result.release();
+		return LK_STATUS_OK;
+	});
+}
+
+lk_status_t lk_audio_source_destroy(lk_audio_source_t* source) {
+	if (source == nullptr) {
+		return LK_STATUS_OK;
+	}
+	if (source->track_references.load() != 0) {
+		return Failure(LK_STATUS_INVALID_STATE, "audio source is still used by a track");
+	}
+	delete source;
+	return LK_STATUS_OK;
+}
+
+lk_status_t lk_audio_source_capture_frame(lk_audio_source_t* source, const int16_t* data,
+                                          uint32_t samples_per_channel) {
+	return Guard([&] {
+		if (source == nullptr || data == nullptr || samples_per_channel == 0) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid audio frame");
+		}
+		return source->source->CaptureFrame(const_cast<int16_t*>(data), source->sample_rate,
+		                                    source->num_channels, samples_per_channel)
+		           ? LK_STATUS_OK
+		           : Failure(LK_STATUS_OPERATION_FAILED, "failed to capture audio frame");
+	});
+}
+
+lk_status_t lk_video_source_create(const lk_video_source_options_t* options,
+                                   lk_video_source_t** source) {
+	return Guard([&] {
+		if (source == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "source output is null");
+		}
+		*source = nullptr;
+		core::VideoSourceOptions core_options;
+		if (options != nullptr) {
+			if (options->struct_size < sizeof(options->struct_size)) {
+				return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid video options struct size");
+			}
+			if (LKC_HAS_FIELD(options, lk_video_source_options_t, is_screencast)) {
+				core_options.is_screencast = options->is_screencast != 0;
+			}
+		}
+		auto result = std::make_unique<lk_video_source_t>();
+		result->source.reset(core::CreateVideoSource(core_options));
+		if (!result->source) {
+			return Failure(LK_STATUS_OPERATION_FAILED, "failed to create video source");
+		}
+		*source = result.release();
+		return LK_STATUS_OK;
+	});
+}
+
+lk_status_t lk_video_source_destroy(lk_video_source_t* source) {
+	if (source == nullptr) {
+		return LK_STATUS_OK;
+	}
+	if (source->track_references.load() != 0) {
+		return Failure(LK_STATUS_INVALID_STATE, "video source is still used by a track");
+	}
+	delete source;
+	return LK_STATUS_OK;
+}
+
+lk_status_t lk_video_source_capture_i420(lk_video_source_t* source, const uint8_t* data,
+                                         size_t data_size, uint32_t width, uint32_t height,
+                                         int64_t timestamp_us) {
+	return Guard([&] {
+		if (source == nullptr || data == nullptr || data_size == 0 || width == 0 || height == 0) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid video frame");
+		}
+		core::VideoFrame frame;
+		frame.data.assign(data, data + data_size);
+		frame.width = width;
+		frame.height = height;
+		frame.timestamp_us = timestamp_us;
+		return source->source->CaptureFrame(frame)
+		           ? LK_STATUS_OK
+		           : Failure(LK_STATUS_OPERATION_FAILED, "failed to capture video frame");
+	});
+}
+
+lk_status_t lk_room_create_audio_track(lk_room_t* room, const char* label,
+                                       lk_audio_source_t* source, lk_local_track_t** track) {
+	return Guard([&] {
+		if (track == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "track output is null");
+		}
+		*track = nullptr;
+		auto* participant = LocalParticipant(room);
+		if (participant == nullptr || label == nullptr || source == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "room, label, and source are required");
+		}
+		auto result = std::make_unique<lk_local_track_t>();
+		result->track.reset(participant->CreateLocalAudioTrack(label, source->source.get()));
+		if (!result->track) {
+			return Failure(LK_STATUS_OPERATION_FAILED, "failed to create audio track");
+		}
+		result->owner = room;
+		result->room_state = room->state;
+		result->audio_source = source;
+		source->track_references.fetch_add(1);
+		*track = result.release();
+		return LK_STATUS_OK;
+	});
+}
+
+lk_status_t lk_room_create_video_track(lk_room_t* room, const char* label,
+                                       lk_video_source_t* source, lk_local_track_t** track) {
+	return Guard([&] {
+		if (track == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "track output is null");
+		}
+		*track = nullptr;
+		auto* participant = LocalParticipant(room);
+		if (participant == nullptr || label == nullptr || source == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "room, label, and source are required");
+		}
+		auto result = std::make_unique<lk_local_track_t>();
+		result->track.reset(participant->CreateLocalVideoTrack(label, source->source.get()));
+		if (!result->track) {
+			return Failure(LK_STATUS_OPERATION_FAILED, "failed to create video track");
+		}
+		result->owner = room;
+		result->room_state = room->state;
+		result->video_source = source;
+		source->track_references.fetch_add(1);
+		*track = result.release();
+		return LK_STATUS_OK;
+	});
+}
+
+lk_status_t lk_local_track_publish(lk_room_t* room, lk_local_track_t* track,
+                                   const lk_track_publish_options_t* options) {
+	return Guard([&] {
+		auto* participant = LocalParticipant(room);
+		if (participant == nullptr || track == nullptr || track->track == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "room and track are required");
+		}
+		if (track->owner != room) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "track belongs to a different room");
+		}
+		if (track->published) {
+			return Failure(LK_STATUS_INVALID_STATE, "track is already published");
+		}
+		core::TrackPublishOptions publish_options;
+		if (options != nullptr) {
+			if (options->struct_size < sizeof(options->struct_size)) {
+				return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid publish options struct size");
+			}
+			if (LKC_HAS_FIELD(options, lk_track_publish_options_t, source)) {
+				publish_options.source = ToCoreTrackSource(options->source);
+			}
+			if (LKC_HAS_FIELD(options, lk_track_publish_options_t, dtx)) {
+				publish_options.dtx = options->dtx != 0;
+			}
+			if (LKC_HAS_FIELD(options, lk_track_publish_options_t, red)) {
+				publish_options.red = options->red != 0;
+			}
+			if (LKC_HAS_FIELD(options, lk_track_publish_options_t, simulcast)) {
+				publish_options.simulcast = options->simulcast != 0;
+			}
+			if (LKC_HAS_FIELD(options, lk_track_publish_options_t, stream) &&
+			    options->stream != nullptr) {
+				publish_options.stream = options->stream;
+			}
+		}
+		if (!participant->PublishTrack(track->track.get(), publish_options)) {
+			return Failure(LK_STATUS_OPERATION_FAILED, "failed to publish track");
+		}
+		track->published = true;
+		return LK_STATUS_OK;
+	});
+}
+
+lk_status_t lk_local_track_destroy(lk_local_track_t* track) {
+	if (track == nullptr) {
+		return LK_STATUS_OK;
+	}
+	if (track->published && track->room_state != nullptr && track->room_state->alive.load() &&
+	    track->room_state->connected.load()) {
+		return Failure(LK_STATUS_INVALID_STATE,
+		               "disconnect the room before destroying a published track");
+	}
+	if (track->audio_source != nullptr) {
+		track->audio_source->track_references.fetch_sub(1);
+	}
+	if (track->video_source != nullptr) {
+		track->video_source->track_references.fetch_sub(1);
+	}
+	delete track;
+	return LK_STATUS_OK;
+}
+
+lk_status_t lk_room_publish_data(lk_room_t* room, const uint8_t* data, size_t data_size,
+                                 const lk_data_publish_options_t* options) {
+	return Guard([&] {
+		auto* participant = LocalParticipant(room);
+		if (participant == nullptr || (data == nullptr && data_size != 0)) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid room or data buffer");
+		}
+		core::DataPublishOptions publish_options;
+		if (options != nullptr) {
+			if (options->struct_size < sizeof(options->struct_size)) {
+				return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid data options struct size");
+			}
+			if (LKC_HAS_FIELD(options, lk_data_publish_options_t, reliable)) {
+				publish_options.reliable = options->reliable != 0;
+			}
+			if (LKC_HAS_FIELD(options, lk_data_publish_options_t, topic) &&
+			    options->topic != nullptr) {
+				publish_options.topic = options->topic;
+			}
+			if (LKC_HAS_FIELD(options, lk_data_publish_options_t, destination_identity_count)) {
+				if (options->destination_identity_count != 0 &&
+				    options->destination_identities == nullptr) {
+					return Failure(LK_STATUS_INVALID_ARGUMENT, "destination identities are null");
+				}
+				publish_options.destination_identities = DestinationIdentities(
+				    options->destination_identities, options->destination_identity_count);
+			}
+		}
+		std::vector<uint8_t> payload;
+		if (data_size != 0) {
+			payload.assign(data, data + data_size);
+		}
+		return participant->PublishData(payload, std::move(publish_options))
+		           ? LK_STATUS_OK
+		           : Failure(LK_STATUS_OPERATION_FAILED, "failed to publish data");
+	});
+}
+
+lk_status_t lk_room_send_file(lk_room_t* room, const char* path,
+                              const lk_file_send_options_t* options) {
+	return Guard([&] {
+		auto* participant = LocalParticipant(room);
+		if (participant == nullptr || path == nullptr || *path == '\0') {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "room and file path are required");
+		}
+		core::FileSendOptions send_options;
+		if (options != nullptr) {
+			if (options->struct_size < sizeof(options->struct_size)) {
+				return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid file options struct size");
+			}
+			if (LKC_HAS_FIELD(options, lk_file_send_options_t, topic) &&
+			    options->topic != nullptr) {
+				send_options.topic = options->topic;
+			}
+			if (LKC_HAS_FIELD(options, lk_file_send_options_t, mime_type) &&
+			    options->mime_type != nullptr) {
+				send_options.mime_type = options->mime_type;
+			}
+			if (LKC_HAS_FIELD(options, lk_file_send_options_t, destination_identity_count)) {
+				if (options->destination_identity_count != 0 &&
+				    options->destination_identities == nullptr) {
+					return Failure(LK_STATUS_INVALID_ARGUMENT, "destination identities are null");
+				}
+				send_options.destination_identities = DestinationIdentities(
+				    options->destination_identities, options->destination_identity_count);
+			}
+			if (LKC_HAS_FIELD(options, lk_file_send_options_t, chunk_size)) {
+				send_options.chunk_size = options->chunk_size;
+			}
+		}
+		return participant->SendFile(path, std::move(send_options))
+		           ? LK_STATUS_OK
+		           : Failure(LK_STATUS_OPERATION_FAILED, "failed to send file");
+	});
+}
+
+} // extern "C"

--- a/test/functional/CMakeLists.txt
+++ b/test/functional/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(livekit_public_api_tests participant_state_test.cpp public_api_test.cpp)
+add_executable(livekit_public_api_tests c_api_test.cpp participant_state_test.cpp public_api_test.cpp)
 target_compile_features(livekit_public_api_tests PRIVATE cxx_std_20)
 target_link_libraries(livekit_public_api_tests PRIVATE livekitclient GTest::gtest_main)
 

--- a/test/functional/c_api_test.cpp
+++ b/test/functional/c_api_test.cpp
@@ -1,0 +1,93 @@
+#include "livekit/capi/livekit.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+TEST(CApiTest, ExposesVersionAndOptionDefaults) {
+	const auto required = lk_version(nullptr, 0);
+	ASSERT_GT(required, 1u);
+	std::vector<char> version(required);
+	EXPECT_EQ(lk_version(version.data(), version.size()), required);
+	EXPECT_STREQ(version.data(), "0.0.1");
+
+	std::array<char, 3> truncated{};
+	EXPECT_EQ(lk_version(truncated.data(), truncated.size()), required);
+	EXPECT_STREQ(truncated.data(), "0.");
+
+	lk_audio_source_options_t audio;
+	lk_audio_source_options_init(&audio);
+	EXPECT_EQ(audio.struct_size, sizeof(audio));
+	EXPECT_EQ(audio.sample_rate, 48000u);
+	EXPECT_EQ(audio.num_channels, 1u);
+	EXPECT_EQ(audio.queue_size_ms, 200u);
+
+	lk_track_publish_options_t publish;
+	lk_track_publish_options_init(&publish);
+	EXPECT_EQ(publish.struct_size, sizeof(publish));
+	EXPECT_EQ(publish.dtx, 1);
+	EXPECT_EQ(publish.red, 1);
+	EXPECT_EQ(publish.simulcast, 1);
+
+	lk_file_send_options_t file;
+	lk_file_send_options_init(&file);
+	EXPECT_EQ(file.struct_size, sizeof(file));
+	EXPECT_STREQ(file.topic, "files");
+	EXPECT_STREQ(file.mime_type, "application/octet-stream");
+	EXPECT_EQ(file.chunk_size, 15000u);
+}
+
+TEST(CApiTest, ValidatesArgumentsWithoutThrowingAcrossAbi) {
+	EXPECT_EQ(lk_room_create(nullptr), LK_STATUS_INVALID_ARGUMENT);
+	EXPECT_NE(std::strlen(lk_last_error()), 0u);
+	EXPECT_EQ(lk_room_connect(nullptr, nullptr, nullptr), LK_STATUS_INVALID_ARGUMENT);
+	EXPECT_EQ(lk_audio_source_capture_frame(nullptr, nullptr, 0), LK_STATUS_INVALID_ARGUMENT);
+	EXPECT_EQ(lk_video_source_capture_i420(nullptr, nullptr, 0, 0, 0, 0),
+	          LK_STATUS_INVALID_ARGUMENT);
+}
+
+TEST(CApiTest, CreatesRoomAndCapturesLocalFrames) {
+	ASSERT_EQ(lk_init(), LK_STATUS_OK) << lk_last_error();
+
+	lk_room_t* room = nullptr;
+	ASSERT_EQ(lk_room_create(&room), LK_STATUS_OK) << lk_last_error();
+	ASSERT_NE(room, nullptr);
+	EXPECT_FALSE(lk_room_is_connected(room));
+	EXPECT_EQ(lk_room_sid(room, nullptr, 0), 1u);
+
+	lk_room_callbacks_t callbacks;
+	lk_room_callbacks_init(&callbacks);
+	EXPECT_EQ(lk_room_set_callbacks(room, &callbacks), LK_STATUS_OK);
+	EXPECT_EQ(lk_room_set_callbacks(room, nullptr), LK_STATUS_OK);
+
+	lk_audio_source_options_t audio_options;
+	lk_audio_source_options_init(&audio_options);
+	lk_audio_source_t* audio = nullptr;
+	ASSERT_EQ(lk_audio_source_create(&audio_options, &audio), LK_STATUS_OK) << lk_last_error();
+	std::vector<int16_t> samples(480, 100);
+	EXPECT_EQ(lk_audio_source_capture_frame(audio, samples.data(), 480), LK_STATUS_OK)
+	    << lk_last_error();
+	EXPECT_EQ(lk_audio_source_destroy(audio), LK_STATUS_OK);
+
+	lk_video_source_options_t video_options;
+	lk_video_source_options_init(&video_options);
+	lk_video_source_t* video = nullptr;
+	ASSERT_EQ(lk_video_source_create(&video_options, &video), LK_STATUS_OK) << lk_last_error();
+	std::vector<uint8_t> i420(12, 128);
+	EXPECT_EQ(lk_video_source_capture_i420(video, i420.data(), i420.size(), 4, 2, 123),
+	          LK_STATUS_OK)
+	    << lk_last_error();
+	i420.pop_back();
+	EXPECT_EQ(lk_video_source_capture_i420(video, i420.data(), i420.size(), 4, 2, 124),
+	          LK_STATUS_OPERATION_FAILED);
+	EXPECT_EQ(lk_video_source_destroy(video), LK_STATUS_OK);
+
+	lk_room_destroy(room);
+	EXPECT_EQ(lk_shutdown(), LK_STATUS_OK) << lk_last_error();
+}
+
+} // namespace


### PR DESCRIPTION
Expose room, participant, media, data, and file operations through opaque C handles and callbacks. Add a pure C11 sample, documentation, and functional coverage.