### PR TITLE
feat: add track controls and room state APIs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,7 @@ Because webrtc requires C++20.
 - [x] WebSocket signaling and room lifecycle
 - [x] Room and participant state, track publications, active speakers, and quality events
 - [x] Participant metadata, display name, and attribute updates
+- [x] Connection state, identity lookup, local track mute, and remote subscription controls
 - [x] Stable C ABI with opaque handles and callbacks
 - [x] Audio publishing and receiving (signed 16-bit PCM)
 - [x] Video publishing and receiving (I420/VP8)

--- a/include/livekit/capi/livekit.h
+++ b/include/livekit/capi/livekit.h
@@ -46,6 +46,14 @@ typedef enum lk_status {
 	LK_STATUS_EXCEPTION = 4
 } lk_status_t;
 
+typedef enum lk_room_state {
+	LK_ROOM_STATE_CONNECTING = 0,
+	LK_ROOM_STATE_CONNECTED = 1,
+	LK_ROOM_STATE_DISCONNECTING = 2,
+	LK_ROOM_STATE_DISCONNECTED = 3,
+	LK_ROOM_STATE_FAILED = 4
+} lk_room_state_t;
+
 typedef enum lk_track_kind {
 	LK_TRACK_KIND_UNKNOWN = 0,
 	LK_TRACK_KIND_AUDIO = 1,
@@ -235,6 +243,7 @@ LKC_API void lk_room_destroy(lk_room_t* room);
 LKC_API lk_status_t lk_room_set_callbacks(lk_room_t* room, const lk_room_callbacks_t* callbacks);
 LKC_API lk_status_t lk_room_connect(lk_room_t* room, const char* url, const char* token);
 LKC_API lk_status_t lk_room_disconnect(lk_room_t* room);
+LKC_API lk_room_state_t lk_room_state(const lk_room_t* room);
 LKC_API int lk_room_is_connected(const lk_room_t* room);
 LKC_API size_t lk_room_sid(const lk_room_t* room, char* buffer, size_t buffer_size);
 LKC_API size_t lk_room_name(const lk_room_t* room, char* buffer, size_t buffer_size);
@@ -271,7 +280,12 @@ LKC_API lk_status_t lk_room_create_video_track(lk_room_t* room, const char* labe
                                                lk_video_source_t* source, lk_local_track_t** track);
 LKC_API lk_status_t lk_local_track_publish(lk_room_t* room, lk_local_track_t* track,
                                            const lk_track_publish_options_t* options);
+LKC_API lk_status_t lk_local_track_set_muted(lk_local_track_t* track, int muted);
 LKC_API lk_status_t lk_local_track_destroy(lk_local_track_t* track);
+
+LKC_API lk_status_t lk_room_set_remote_track_subscribed(lk_room_t* room,
+                                                        const char* participant_sid,
+                                                        const char* track_sid, int subscribed);
 
 LKC_API lk_status_t lk_room_publish_data(lk_room_t* room, const uint8_t* data, size_t data_size,
                                          const lk_data_publish_options_t* options);

--- a/include/livekit/core/room_interface.h
+++ b/include/livekit/core/room_interface.h
@@ -50,6 +50,9 @@ public:
 	virtual void AddEventListener(RoomEventInterface* listener) = 0;
 	virtual void RemoveEventListener() = 0;
 
+	// Returns the full connection lifecycle state. Unlike IsConnected(), this distinguishes
+	// connecting, disconnecting, and failed rooms.
+	RoomState State() const;
 	virtual bool IsConnected() = 0;
 	virtual bool Disconnect() = 0;
 	virtual std::string Sid() { return {}; }
@@ -60,10 +63,20 @@ public:
 	virtual LocalParticipantInterface* GetLocalParticipant() = 0;
 	virtual std::vector<RemoteParticipantInterface*> GetRemoteParticipants() = 0;
 	virtual RemoteParticipantInterface* GetRemoteParticipantBySid(std::string sid) = 0;
+	// LiveKit identity is stable for a participant session and should normally be preferred over
+	// the mutable display name.
+	RemoteParticipantInterface* GetRemoteParticipantByIdentity(std::string identity);
 	virtual RemoteParticipantInterface* GetRemoteParticipantByName(std::string name) = 0;
 	virtual std::vector<ParticipantInterface*> Participants() = 0;
 	virtual ParticipantInterface* GetParticipantBySid(std::string sid) = 0;
+	ParticipantInterface* GetParticipantByIdentity(std::string identity);
 	virtual ParticipantInterface* GetParticipantByName(std::string name) = 0;
+
+	// These controls return false when the room is disconnected or the participant/track SID does
+	// not belong to the room.
+	bool SetLocalTrackMuted(std::string track_sid, bool muted);
+	bool SetRemoteTrackSubscribed(std::string participant_sid, std::string track_sid,
+	                              bool subscribed);
 };
 
 RoomInterface* CreateRoom();

--- a/src/capi/livekit.cpp
+++ b/src/capi/livekit.cpp
@@ -166,6 +166,21 @@ lk_connection_quality_t ToCConnectionQuality(core::ConnectionQuality quality) {
 	}
 }
 
+lk_room_state_t ToCRoomState(core::RoomInterface::RoomState state) {
+	switch (state) {
+	case core::RoomInterface::RoomState::Connecting:
+		return LK_ROOM_STATE_CONNECTING;
+	case core::RoomInterface::RoomState::Connected:
+		return LK_ROOM_STATE_CONNECTED;
+	case core::RoomInterface::RoomState::Disconnecting:
+		return LK_ROOM_STATE_DISCONNECTING;
+	case core::RoomInterface::RoomState::Failed:
+		return LK_ROOM_STATE_FAILED;
+	default:
+		return LK_ROOM_STATE_DISCONNECTED;
+	}
+}
+
 struct OwnedParticipantInfo {
 	explicit OwnedParticipantInfo(core::ParticipantInterface* participant) {
 		if (participant == nullptr) {
@@ -641,6 +656,13 @@ lk_status_t lk_room_disconnect(lk_room_t* room) {
 	});
 }
 
+lk_room_state_t lk_room_state(const lk_room_t* room) {
+	if (room == nullptr || room->room == nullptr) {
+		return LK_ROOM_STATE_DISCONNECTED;
+	}
+	return ToCRoomState(room->room->State());
+}
+
 int lk_room_is_connected(const lk_room_t* room) {
 	return room != nullptr && room->room != nullptr && room->room->IsConnected() ? 1 : 0;
 }
@@ -963,6 +985,21 @@ lk_status_t lk_local_track_publish(lk_room_t* room, lk_local_track_t* track,
 	});
 }
 
+lk_status_t lk_local_track_set_muted(lk_local_track_t* track, int muted) {
+	return Guard([&] {
+		if (track == nullptr || track->track == nullptr || track->owner == nullptr ||
+		    track->room_state == nullptr || !track->room_state->alive.load()) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "live local track is required");
+		}
+		if (!track->published) {
+			return Failure(LK_STATUS_INVALID_STATE, "track is not published");
+		}
+		return track->owner->room->SetLocalTrackMuted(track->track->Sid(), muted != 0)
+		           ? LK_STATUS_OK
+		           : Failure(LK_STATUS_OPERATION_FAILED, "failed to update track mute state");
+	});
+}
+
 lk_status_t lk_local_track_destroy(lk_local_track_t* track) {
 	if (track == nullptr) {
 		return LK_STATUS_OK;
@@ -980,6 +1017,20 @@ lk_status_t lk_local_track_destroy(lk_local_track_t* track) {
 	}
 	delete track;
 	return LK_STATUS_OK;
+}
+
+lk_status_t lk_room_set_remote_track_subscribed(lk_room_t* room, const char* participant_sid,
+                                                const char* track_sid, int subscribed) {
+	return Guard([&] {
+		if (room == nullptr || participant_sid == nullptr || track_sid == nullptr ||
+		    *participant_sid == '\0' || *track_sid == '\0') {
+			return Failure(LK_STATUS_INVALID_ARGUMENT,
+			               "room, participant SID, and track SID are required");
+		}
+		return room->room->SetRemoteTrackSubscribed(participant_sid, track_sid, subscribed != 0)
+		           ? LK_STATUS_OK
+		           : Failure(LK_STATUS_OPERATION_FAILED, "failed to update track subscription");
+	});
 }
 
 lk_status_t lk_room_publish_data(lk_room_t* room, const uint8_t* data, size_t data_size,

--- a/src/core/detail/rtc_engine.cpp
+++ b/src/core/detail/rtc_engine.cpp
@@ -218,6 +218,37 @@ bool RtcEngine::SendDataPacket(const livekit::DataPacket& packet, bool reliable)
 	    webrtc::DataBuffer(webrtc::CopyOnWriteBuffer(serialized.data(), serialized.size()), true));
 }
 
+bool RtcEngine::SetTrackMuted(const std::string& track_sid, bool muted) {
+	if (track_sid.empty()) {
+		return false;
+	}
+	std::lock_guard<std::mutex> guard(session_lock_);
+	if (!signal_client_) {
+		return false;
+	}
+	signal_client_->SendMuteTrack(track_sid, muted);
+	return true;
+}
+
+bool RtcEngine::SetTrackSubscribed(const std::string& participant_sid, const std::string& track_sid,
+                                   bool subscribed) {
+	if (participant_sid.empty() || track_sid.empty()) {
+		return false;
+	}
+	std::lock_guard<std::mutex> guard(session_lock_);
+	if (!signal_client_) {
+		return false;
+	}
+	livekit::UpdateSubscription update;
+	update.set_subscribe(subscribed);
+	update.add_track_sids(track_sid);
+	auto* participant_tracks = update.add_participant_tracks();
+	participant_tracks->set_participant_sid(participant_sid);
+	participant_tracks->add_track_sids(track_sid);
+	signal_client_->SendUpdateSubscription(update);
+	return true;
+}
+
 bool RtcEngine::UpdateLocalMetadata(const std::string& metadata, const std::string& name,
                                     const std::map<std::string, std::string>& attributes) {
 	if (!signal_client_) {

--- a/src/core/detail/rtc_engine.h
+++ b/src/core/detail/rtc_engine.h
@@ -78,6 +78,9 @@ public:
 
 	void PublisherNegotiationNeeded();
 	bool SendDataPacket(const livekit::DataPacket& packet, bool reliable);
+	bool SetTrackMuted(const std::string& track_sid, bool muted);
+	bool SetTrackSubscribed(const std::string& participant_sid, const std::string& track_sid,
+	                        bool subscribed);
 	bool UpdateLocalMetadata(const std::string& metadata, const std::string& name,
 	                         const std::map<std::string, std::string>& attributes);
 

--- a/src/core/detail/signal_client.cpp
+++ b/src/core/detail/signal_client.cpp
@@ -182,7 +182,7 @@ void SignalClient::SendIceCandidate(std::string& candidate, livekit::SignalTarge
 	return;
 }
 
-void SignalClient::SendMuteTrack(std::string& track_sid, bool muted) {
+void SignalClient::SendMuteTrack(const std::string& track_sid, bool muted) {
 	livekit::SignalRequest request;
 	auto* mute_msg = request.mutable_mute();
 	mute_msg->set_sid(track_sid);

--- a/src/core/detail/signal_client.h
+++ b/src/core/detail/signal_client.h
@@ -113,7 +113,7 @@ public:
 
 	void SendIceCandidate(std::string& candidate, livekit::SignalTarget target);
 
-	void SendMuteTrack(std::string& track_sid, bool muted);
+	void SendMuteTrack(const std::string& track_sid, bool muted);
 
 	void SendAddTrack(const livekit::AddTrackRequest& request);
 

--- a/src/core/room.cpp
+++ b/src/core/room.cpp
@@ -136,6 +136,8 @@ void Room::RemoveEventListener() { event_listener_.store(nullptr); }
 
 bool Room::IsConnected() { return state_.load() == RoomState::Connected; }
 
+RoomInterface::RoomState Room::State() const { return state_.load(); }
+
 std::string Room::Sid() {
 	std::lock_guard<std::mutex> guard(room_info_mutex_);
 	return room_info_.sid();
@@ -235,6 +237,87 @@ ParticipantInterface* Room::GetParticipantByName(std::string name) {
 		return this->local_participant_.get();
 	}
 	return GetRemoteParticipantByName(std::move(name));
+}
+
+bool Room::SetLocalTrackMutedInternal(std::string track_sid, bool muted) {
+	if (track_sid.empty()) {
+		return false;
+	}
+	auto publications = local_participant_->TrackPublicationsSnapshot();
+	auto found = publications.find(track_sid);
+	if (found == publications.end() || !rtc_engine_->SetTrackMuted(track_sid, muted)) {
+		return false;
+	}
+	if (auto* local_track = dynamic_cast<LocalTrack*>(found->second->Track())) {
+		if (local_track->media_track() != nullptr) {
+			local_track->media_track()->set_enabled(!muted);
+		}
+	}
+	if (auto* publication = dynamic_cast<TrackPublication*>(found->second.get())) {
+		publication->SetMuted(muted);
+	}
+	if (auto* listener = event_listener_.load()) {
+		if (muted) {
+			listener->OnTrackMuted(found->second.get(), local_participant_.get());
+		} else {
+			listener->OnTrackUnmuted(found->second.get(), local_participant_.get());
+		}
+	}
+	return true;
+}
+
+bool Room::SetRemoteTrackSubscribedInternal(std::string participant_sid, std::string track_sid,
+                                            bool subscribed) {
+	if (participant_sid.empty() || track_sid.empty()) {
+		return false;
+	}
+	{
+		std::lock_guard<std::mutex> guard(participants_mutex_);
+		auto participant = remote_participants_.find(participant_sid);
+		if (participant == remote_participants_.end() ||
+		    !participant->second->HasTrackSid(track_sid)) {
+			return false;
+		}
+	}
+	return rtc_engine_->SetTrackSubscribed(participant_sid, track_sid, subscribed);
+}
+
+RoomInterface::RoomState RoomInterface::State() const {
+	auto* room = dynamic_cast<const Room*>(this);
+	if (room != nullptr) {
+		return room->State();
+	}
+	return const_cast<RoomInterface*>(this)->IsConnected() ? RoomState::Connected
+	                                                       : RoomState::Disconnected;
+}
+
+RemoteParticipantInterface* RoomInterface::GetRemoteParticipantByIdentity(std::string identity) {
+	for (auto* participant : GetRemoteParticipants()) {
+		if (participant != nullptr && participant->Identity() == identity) {
+			return participant;
+		}
+	}
+	return nullptr;
+}
+
+ParticipantInterface* RoomInterface::GetParticipantByIdentity(std::string identity) {
+	auto* local = GetLocalParticipant();
+	if (local != nullptr && local->Identity() == identity) {
+		return local;
+	}
+	return GetRemoteParticipantByIdentity(std::move(identity));
+}
+
+bool RoomInterface::SetLocalTrackMuted(std::string track_sid, bool muted) {
+	auto* room = dynamic_cast<Room*>(this);
+	return room != nullptr && room->SetLocalTrackMutedInternal(std::move(track_sid), muted);
+}
+
+bool RoomInterface::SetRemoteTrackSubscribed(std::string participant_sid, std::string track_sid,
+                                             bool subscribed) {
+	auto* room = dynamic_cast<Room*>(this);
+	return room != nullptr && room->SetRemoteTrackSubscribedInternal(
+	                              std::move(participant_sid), std::move(track_sid), subscribed);
 }
 
 void Room::ConnectedEvent(livekit::JoinResponse join_resp) {

--- a/src/core/room.h
+++ b/src/core/room.h
@@ -45,6 +45,7 @@ public:
 	                     RoomConnectOptions opts = default_room_connect_options()) override;
 	virtual void AddEventListener(RoomEventInterface* listener) override;
 	virtual void RemoveEventListener() override;
+	RoomState State() const;
 	virtual bool IsConnected() override;
 	virtual bool Disconnect() override;
 	std::string Sid() override;
@@ -58,6 +59,9 @@ public:
 	virtual std::vector<ParticipantInterface*> Participants() override;
 	virtual ParticipantInterface* GetParticipantBySid(std::string sid) override;
 	virtual ParticipantInterface* GetParticipantByName(std::string name) override;
+	bool SetLocalTrackMutedInternal(std::string track_sid, bool muted);
+	bool SetRemoteTrackSubscribedInternal(std::string participant_sid, std::string track_sid,
+	                                      bool subscribed);
 
 	/* Pure virtual methods inherited from RtcEngineListener */
 public:

--- a/test/functional/c_api_test.cpp
+++ b/test/functional/c_api_test.cpp
@@ -56,6 +56,7 @@ TEST(CApiTest, CreatesRoomAndCapturesLocalFrames) {
 	lk_room_t* room = nullptr;
 	ASSERT_EQ(lk_room_create(&room), LK_STATUS_OK) << lk_last_error();
 	ASSERT_NE(room, nullptr);
+	EXPECT_EQ(lk_room_state(room), LK_ROOM_STATE_DISCONNECTED);
 	EXPECT_FALSE(lk_room_is_connected(room));
 	EXPECT_EQ(lk_room_sid(room, nullptr, 0), 1u);
 
@@ -63,6 +64,8 @@ TEST(CApiTest, CreatesRoomAndCapturesLocalFrames) {
 	lk_room_callbacks_init(&callbacks);
 	EXPECT_EQ(lk_room_set_callbacks(room, &callbacks), LK_STATUS_OK);
 	EXPECT_EQ(lk_room_set_callbacks(room, nullptr), LK_STATUS_OK);
+	EXPECT_EQ(lk_room_set_remote_track_subscribed(room, "missing", "missing", 1),
+	          LK_STATUS_OPERATION_FAILED);
 
 	lk_audio_source_options_t audio_options;
 	lk_audio_source_options_init(&audio_options);

--- a/test/functional/participant_state_test.cpp
+++ b/test/functional/participant_state_test.cpp
@@ -1,4 +1,5 @@
 #include "../../src/core/participant/remote_participant.h"
+#include "../../src/core/room.h"
 
 #include "livekit_models.pb.h"
 
@@ -99,6 +100,21 @@ TEST(ParticipantStateTest, IgnoresOutOfOrderParticipantSnapshots) {
 
 	EXPECT_EQ(participant.Metadata(), "new");
 	EXPECT_NE(participant.GetTrackPublication(TrackSource::Camera), nullptr);
+}
+
+TEST(ParticipantStateTest, FindsRemoteParticipantByIdentity) {
+	Room room;
+	livekit::ParticipantInfo info;
+	info.set_sid("PA_remote");
+	info.set_identity("remote-identity");
+	info.set_name("Remote User");
+	room.ParticipantUpdateEvent({info});
+
+	auto* participant = room.GetRemoteParticipantByIdentity("remote-identity");
+	ASSERT_NE(participant, nullptr);
+	EXPECT_EQ(participant->Sid(), "PA_remote");
+	EXPECT_EQ(room.GetParticipantByIdentity("remote-identity"), participant);
+	EXPECT_EQ(room.GetRemoteParticipantByIdentity("Remote User"), nullptr);
 }
 
 } // namespace

--- a/test/functional/public_api_test.cpp
+++ b/test/functional/public_api_test.cpp
@@ -20,12 +20,16 @@ TEST(ClientLifecycleTest, InitAndDestroyAreReferenceCounted) {
 TEST(PublicApiTest, CreatesOwnedDisconnectedRoom) {
 	auto room = CreateRoomUnique();
 	ASSERT_NE(room, nullptr);
+	EXPECT_EQ(room->State(), RoomInterface::RoomState::Disconnected);
 	EXPECT_FALSE(room->IsConnected());
 	EXPECT_NE(room->GetLocalParticipant(), nullptr);
 	EXPECT_TRUE(room->Sid().empty());
 	EXPECT_TRUE(room->Name().empty());
 	EXPECT_TRUE(room->Metadata().empty());
 	EXPECT_FALSE(room->IsRecording());
+	EXPECT_EQ(room->GetRemoteParticipantByIdentity("missing"), nullptr);
+	EXPECT_FALSE(room->SetLocalTrackMuted("missing", true));
+	EXPECT_FALSE(room->SetRemoteTrackSubscribed("missing", "missing", true));
 }
 
 TEST(PublicApiTest, ExposesSemanticVersion) { EXPECT_EQ(Version(), "0.0.1"); }

--- a/test/integration/livekit_server_test.cpp
+++ b/test/integration/livekit_server_test.cpp
@@ -340,6 +340,8 @@ TEST(LiveKitServerTest, PublishesAndReceivesAudioAndVideo) {
 	ASSERT_TRUE(sender->Connect(url, sender_token));
 	ASSERT_TRUE(WaitUntil([&] { return receiver->IsConnected() && sender->IsConnected(); },
 	                      std::chrono::seconds(10)));
+	EXPECT_EQ(receiver->State(), RoomInterface::RoomState::Connected);
+	EXPECT_EQ(sender->State(), RoomInterface::RoomState::Connected);
 
 	auto audio_source = CreateAudioSourceUnique({}, 48000, 1, 200);
 	auto audio_track = sender->GetLocalParticipant()->CreateLocalAudioTrackUnique(
@@ -358,9 +360,15 @@ TEST(LiveKitServerTest, PublishesAndReceivesAudioAndVideo) {
 	ASSERT_NE(sender_participant, nullptr);
 	auto* audio_publication = sender_participant->GetTrackPublication(TrackSource::Microphone);
 	ASSERT_NE(audio_publication, nullptr);
+	EXPECT_EQ(receiver->GetRemoteParticipantByIdentity(sender->GetLocalParticipant()->Identity()),
+	          sender_participant);
 	EXPECT_EQ(audio_publication->Name(), "integration-audio");
 	EXPECT_EQ(audio_publication->Kind(), TrackKind::Audio);
 	EXPECT_FALSE(audio_publication->IsMuted());
+	ASSERT_TRUE(sender->SetLocalTrackMuted(audio_track->Sid(), true));
+	ASSERT_TRUE(WaitUntil([&] { return audio_publication->IsMuted(); }));
+	ASSERT_TRUE(sender->SetLocalTrackMuted(audio_track->Sid(), false));
+	ASSERT_TRUE(WaitUntil([&] { return !audio_publication->IsMuted(); }));
 
 	std::vector<int16_t> audio_samples(480, 1500);
 	const auto audio_deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
@@ -407,6 +415,10 @@ TEST(LiveKitServerTest, PublishesAndReceivesAudioAndVideo) {
 	    << PublicationSummary(sender_participant);
 	auto* video_publication = sender_participant->GetTrackPublication(TrackSource::Camera);
 	ASSERT_NE(video_publication, nullptr);
+	ASSERT_TRUE(receiver->SetRemoteTrackSubscribed(sender_participant->Sid(),
+	                                               video_publication->Sid(), false));
+	ASSERT_TRUE(receiver->SetRemoteTrackSubscribed(sender_participant->Sid(),
+	                                               video_publication->Sid(), true));
 	EXPECT_EQ(video_publication->Name(), "integration-video");
 	EXPECT_EQ(video_publication->Kind(), TrackKind::Video);
 	EXPECT_TRUE(sender_participant->IsCameraEnabled());


### PR DESCRIPTION
Align the client with common JS and Go SDK controls by exposing connection state, participant identity lookup, local track mute, and remote subscription updates. Mirror the controls in the C API and cover them with functional and LiveKit integration tests.