### PR TITLE
feat: add local track unpublish lifecycle

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -84,6 +84,8 @@ Start this example before a publisher when verifying media or file reception.
 ### `publish_audio`
 
 Publishes a synthetic mono 440 Hz, 48 kHz signed 16-bit PCM tone for five seconds.
+The example explicitly unpublishes the track before destroying it, demonstrating the same
+publish/unpublish lifecycle exposed by the official client SDKs.
 
 ```powershell
 & "out/build/vs2022-x64-release/examples/publish_audio/Release/publish_audio.exe" `
@@ -94,6 +96,11 @@ Publishes a synthetic mono 440 Hz, 48 kHz signed 16-bit PCM tone for five second
 
 Publishes synthetic 640x360 I420 video at approximately 30 frames per second for five seconds.
 The SDK encodes the frames as VP8 for transport.
+It then unpublishes the local track and renegotiates before disconnecting.
+
+Applications that need to rebuild every publisher sender after reconnecting or changing common
+publish settings can call `LocalParticipantInterface::RepublishAllTracks()`. The C API exposes the
+same operation as `lk_room_republish_all_tracks()`.
 
 ```powershell
 & "out/build/vs2022-x64-release/examples/publish_video/Release/publish_video.exe" `

--- a/examples/publish_audio/publish_audio.cpp
+++ b/examples/publish_audio/publish_audio.cpp
@@ -58,6 +58,10 @@ int main(int argc, char* argv[]) {
 	}
 
 	std::cout << "Published a 440 Hz audio tone for 5 seconds" << std::endl;
+	if (!room->GetLocalParticipant()->UnpublishTrack(track.get())) {
+		std::cerr << "Failed to unpublish audio track" << std::endl;
+		return 1;
+	}
 	track.reset();
 	source.reset();
 	room->Disconnect();

--- a/examples/publish_video/publish_video.cpp
+++ b/examples/publish_video/publish_video.cpp
@@ -67,6 +67,10 @@ int main(int argc, char* argv[]) {
 	}
 
 	std::cout << "Published 640x360 synthetic video for 5 seconds" << std::endl;
+	if (!room->GetLocalParticipant()->UnpublishTrack(track.get())) {
+		std::cerr << "Failed to unpublish video track" << std::endl;
+		return 1;
+	}
 	track.reset();
 	source.reset();
 	room->Disconnect();

--- a/include/livekit/capi/livekit.h
+++ b/include/livekit/capi/livekit.h
@@ -183,6 +183,8 @@ typedef struct lk_room_callbacks {
 	lk_room_metadata_callback on_room_metadata_changed;
 	lk_connection_quality_callback on_connection_quality_changed;
 	lk_active_speakers_callback on_active_speakers_changed;
+	lk_track_event_callback on_local_track_published;
+	lk_track_event_callback on_local_track_unpublished;
 } lk_room_callbacks_t;
 
 typedef struct lk_audio_source_options {
@@ -280,6 +282,8 @@ LKC_API lk_status_t lk_room_create_video_track(lk_room_t* room, const char* labe
                                                lk_video_source_t* source, lk_local_track_t** track);
 LKC_API lk_status_t lk_local_track_publish(lk_room_t* room, lk_local_track_t* track,
                                            const lk_track_publish_options_t* options);
+LKC_API lk_status_t lk_local_track_unpublish(lk_local_track_t* track, int stop_on_unpublish);
+LKC_API lk_status_t lk_room_republish_all_tracks(lk_room_t* room);
 LKC_API lk_status_t lk_local_track_set_muted(lk_local_track_t* track, int muted);
 LKC_API lk_status_t lk_local_track_destroy(lk_local_track_t* track);
 

--- a/include/livekit/core/participant/local_participant_interface.h
+++ b/include/livekit/core/participant/local_participant_interface.h
@@ -62,6 +62,13 @@ public:
 	}
 
 	virtual bool PublishTrack(LocalTrackInterface* track, TrackPublishOptions option) = 0;
+	// Removes a published track from the publisher PeerConnection. The track object remains owned
+	// by the caller and may be published again. When stop_on_unpublish is true its media source is
+	// disabled after the sender has been removed.
+	virtual bool UnpublishTrack(LocalTrackInterface* track, bool stop_on_unpublish = true) = 0;
+	virtual std::size_t UnpublishTracks(const std::vector<LocalTrackInterface*>& tracks,
+	                                    bool stop_on_unpublish = true) = 0;
+	virtual bool RepublishAllTracks() = 0;
 	virtual bool SetMetadata(const std::string&) { return false; }
 	virtual bool SetName(const std::string&) { return false; }
 	virtual bool SetAttributes(const std::map<std::string, std::string>&) { return false; }

--- a/include/livekit/core/room_event_interface.h
+++ b/include/livekit/core/room_event_interface.h
@@ -47,6 +47,8 @@ public:
 	virtual void OnParticipantDisconnected(RemoteParticipantInterface*) {}
 	virtual void OnTrackPublished(TrackPublicationInterface*, RemoteParticipantInterface*) {}
 	virtual void OnTrackUnpublished(TrackPublicationInterface*, RemoteParticipantInterface*) {}
+	virtual void OnLocalTrackPublished(TrackPublicationInterface*, ParticipantInterface*) {}
+	virtual void OnLocalTrackUnpublished(TrackPublicationInterface*, ParticipantInterface*) {}
 	virtual void OnTrackMuted(TrackPublicationInterface*, ParticipantInterface*) {}
 	virtual void OnTrackUnmuted(TrackPublicationInterface*, ParticipantInterface*) {}
 	virtual void OnTrackSubscribed(RemoteTrackInterface*, RemoteParticipantInterface*) {}

--- a/src/capi/livekit.cpp
+++ b/src/capi/livekit.cpp
@@ -31,6 +31,8 @@ struct lk_room {
 	std::unique_ptr<CRoomEvents> events;
 	std::mutex callbacks_mutex;
 	std::mutex callback_lifetime_mutex;
+	std::mutex local_tracks_mutex;
+	std::vector<lk_local_track_t*> local_tracks;
 	lk_room_callbacks_t callbacks{};
 	std::shared_ptr<RoomHandleState> state = std::make_shared<RoomHandleState>();
 };
@@ -53,7 +55,7 @@ struct lk_local_track {
 	lk_audio_source_t* audio_source = nullptr;
 	lk_video_source_t* video_source = nullptr;
 	std::shared_ptr<RoomHandleState> room_state;
-	bool published = false;
+	std::atomic_bool published{false};
 };
 
 namespace {
@@ -351,6 +353,19 @@ public:
 		Track(callbacks_member(&lk_room_callbacks_t::on_track_unpublished), track, participant);
 	}
 
+	void OnLocalTrackPublished(core::TrackPublicationInterface* track,
+	                           core::ParticipantInterface* participant) override {
+		MarkLocalTrackPublished(track, true);
+		Track(callbacks_member(&lk_room_callbacks_t::on_local_track_published), track, participant);
+	}
+
+	void OnLocalTrackUnpublished(core::TrackPublicationInterface* track,
+	                             core::ParticipantInterface* participant) override {
+		MarkLocalTrackPublished(track, false);
+		Track(callbacks_member(&lk_room_callbacks_t::on_local_track_unpublished), track,
+		      participant);
+	}
+
 	void OnTrackMuted(core::TrackPublicationInterface* track,
 	                  core::ParticipantInterface* participant) override {
 		Track(callbacks_member(&lk_room_callbacks_t::on_track_muted), track, participant);
@@ -471,6 +486,20 @@ public:
 
 private:
 	template <typename Member> static Member callbacks_member(Member member) { return member; }
+
+	void MarkLocalTrackPublished(core::TrackPublicationInterface* publication, bool published) {
+		if (owner_ == nullptr || publication == nullptr) {
+			return;
+		}
+		auto* local_track = publication->Track();
+		std::lock_guard<std::mutex> guard(owner_->local_tracks_mutex);
+		for (auto* handle : owner_->local_tracks) {
+			if (handle != nullptr && handle->track.get() == local_track) {
+				handle->published.store(published);
+				break;
+			}
+		}
+	}
 
 	void Participant(lk_participant_event_callback lk_room_callbacks_t::*callback,
 	                 core::ParticipantInterface* participant) {
@@ -603,6 +632,15 @@ void lk_room_destroy(lk_room_t* room) {
 		}
 		room->state->connected.store(false);
 		room->state->alive.store(false);
+		{
+			std::lock_guard<std::mutex> guard(room->local_tracks_mutex);
+			for (auto* track : room->local_tracks) {
+				if (track != nullptr) {
+					track->owner = nullptr;
+				}
+			}
+			room->local_tracks.clear();
+		}
 		{ std::lock_guard<std::mutex> guard(room->callback_lifetime_mutex); }
 		delete room;
 	} catch (...) {
@@ -912,6 +950,10 @@ lk_status_t lk_room_create_audio_track(lk_room_t* room, const char* label,
 		result->room_state = room->state;
 		result->audio_source = source;
 		source->track_references.fetch_add(1);
+		{
+			std::lock_guard<std::mutex> guard(room->local_tracks_mutex);
+			room->local_tracks.push_back(result.get());
+		}
 		*track = result.release();
 		return LK_STATUS_OK;
 	});
@@ -937,6 +979,10 @@ lk_status_t lk_room_create_video_track(lk_room_t* room, const char* label,
 		result->room_state = room->state;
 		result->video_source = source;
 		source->track_references.fetch_add(1);
+		{
+			std::lock_guard<std::mutex> guard(room->local_tracks_mutex);
+			room->local_tracks.push_back(result.get());
+		}
 		*track = result.release();
 		return LK_STATUS_OK;
 	});
@@ -952,7 +998,7 @@ lk_status_t lk_local_track_publish(lk_room_t* room, lk_local_track_t* track,
 		if (track->owner != room) {
 			return Failure(LK_STATUS_INVALID_ARGUMENT, "track belongs to a different room");
 		}
-		if (track->published) {
+		if (track->published.load()) {
 			return Failure(LK_STATUS_INVALID_STATE, "track is already published");
 		}
 		core::TrackPublishOptions publish_options;
@@ -980,8 +1026,39 @@ lk_status_t lk_local_track_publish(lk_room_t* room, lk_local_track_t* track,
 		if (!participant->PublishTrack(track->track.get(), publish_options)) {
 			return Failure(LK_STATUS_OPERATION_FAILED, "failed to publish track");
 		}
-		track->published = true;
+		track->published.store(true);
 		return LK_STATUS_OK;
+	});
+}
+
+lk_status_t lk_local_track_unpublish(lk_local_track_t* track, int stop_on_unpublish) {
+	return Guard([&] {
+		if (track == nullptr || track->track == nullptr || track->owner == nullptr ||
+		    track->room_state == nullptr || !track->room_state->alive.load()) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "live local track is required");
+		}
+		if (!track->published.load()) {
+			return Failure(LK_STATUS_INVALID_STATE, "track is not published");
+		}
+		auto* participant = LocalParticipant(track->owner);
+		if (participant == nullptr ||
+		    !participant->UnpublishTrack(track->track.get(), stop_on_unpublish != 0)) {
+			return Failure(LK_STATUS_OPERATION_FAILED, "failed to unpublish track");
+		}
+		track->published.store(false);
+		return LK_STATUS_OK;
+	});
+}
+
+lk_status_t lk_room_republish_all_tracks(lk_room_t* room) {
+	return Guard([&] {
+		auto* participant = LocalParticipant(room);
+		if (participant == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "live room is required");
+		}
+		return participant->RepublishAllTracks()
+		           ? LK_STATUS_OK
+		           : Failure(LK_STATUS_OPERATION_FAILED, "failed to republish all tracks");
 	});
 }
 
@@ -991,7 +1068,7 @@ lk_status_t lk_local_track_set_muted(lk_local_track_t* track, int muted) {
 		    track->room_state == nullptr || !track->room_state->alive.load()) {
 			return Failure(LK_STATUS_INVALID_ARGUMENT, "live local track is required");
 		}
-		if (!track->published) {
+		if (!track->published.load()) {
 			return Failure(LK_STATUS_INVALID_STATE, "track is not published");
 		}
 		return track->owner->room->SetLocalTrackMuted(track->track->Sid(), muted != 0)
@@ -1004,10 +1081,16 @@ lk_status_t lk_local_track_destroy(lk_local_track_t* track) {
 	if (track == nullptr) {
 		return LK_STATUS_OK;
 	}
-	if (track->published && track->room_state != nullptr && track->room_state->alive.load() &&
-	    track->room_state->connected.load()) {
+	if (track->published.load() && track->room_state != nullptr &&
+	    track->room_state->alive.load() && track->room_state->connected.load()) {
 		return Failure(LK_STATUS_INVALID_STATE,
 		               "disconnect the room before destroying a published track");
+	}
+	if (track->owner != nullptr && track->room_state != nullptr &&
+	    track->room_state->alive.load()) {
+		std::lock_guard<std::mutex> guard(track->owner->local_tracks_mutex);
+		auto& tracks = track->owner->local_tracks;
+		tracks.erase(std::remove(tracks.begin(), tracks.end(), track), tracks.end());
 	}
 	if (track->audio_source != nullptr) {
 		track->audio_source->track_references.fetch_sub(1);

--- a/src/core/detail/peer_transport.cpp
+++ b/src/core/detail/peer_transport.cpp
@@ -437,6 +437,23 @@ PeerTransport::AddTransceiver(webrtc::scoped_refptr<webrtc::MediaStreamTrackInte
 	return result.value();
 }
 
+bool PeerTransport::RemoveTrack(
+    webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver) {
+	if (!transceiver) {
+		return false;
+	}
+	std::lock_guard<std::mutex> guard(pc_lock_);
+	if (!pc_ || !transceiver->sender()) {
+		return false;
+	}
+	const auto direction_error =
+	    transceiver->SetDirectionWithError(webrtc::RtpTransceiverDirection::kInactive);
+	if (!direction_error.ok()) {
+		return false;
+	}
+	return pc_->RemoveTrackOrError(transceiver->sender()).ok();
+}
+
 webrtc::scoped_refptr<webrtc::DataChannelInterface>
 PeerTransport::CreateDataChannel(const std::string& label, const webrtc::DataChannelInit* config) {
 	const auto result = this->pc_->CreateDataChannelOrError(label, config);

--- a/src/core/detail/peer_transport.h
+++ b/src/core/detail/peer_transport.h
@@ -193,6 +193,7 @@ public:
 	webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>
 	AddTransceiver(webrtc::scoped_refptr<webrtc::MediaStreamTrackInterface> track,
 	               webrtc::RtpTransceiverInit rtpTransceiverInit);
+	bool RemoveTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver);
 
 	webrtc::scoped_refptr<webrtc::DataChannelInterface>
 	CreateDataChannel(const std::string& label, const webrtc::DataChannelInit* config);

--- a/src/core/detail/rtc_engine.cpp
+++ b/src/core/detail/rtc_engine.cpp
@@ -169,6 +169,11 @@ RtcEngine::CreateSender(LocalTrack* track, TrackPublishOptions options,
 	return nullptr;
 }
 
+bool RtcEngine::RemoveSender(LocalTrack* track) {
+	std::lock_guard<std::mutex> guard(session_lock_);
+	return rtc_session_ != nullptr && rtc_session_->RemoveSender(track);
+}
+
 void RtcEngine::PublisherNegotiationNeeded() {
 	std::lock_guard<std::mutex> guard(session_lock_);
 	if (rtc_session_) {
@@ -280,7 +285,9 @@ void RtcEngine::OnLocalTrackPublished(const livekit::TrackPublishedResponse& res
 }
 
 void RtcEngine::OnLocalTrackUnpublished(const livekit::TrackUnpublishedResponse& response) {
-	return;
+	if (auto* listener = room_listener_.load()) {
+		listener->LocalTrackUnpublishedEvent(response.track_sid());
+	}
 }
 
 void RtcEngine::OnOffer(std::unique_ptr<webrtc::SessionDescriptionInterface> offer) {

--- a/src/core/detail/rtc_engine.h
+++ b/src/core/detail/rtc_engine.h
@@ -54,6 +54,7 @@ public:
 		MediaTrackEvent(webrtc::scoped_refptr<webrtc::MediaStreamTrackInterface> track) = 0;
 		virtual void DataPacketEvent(const livekit::DataPacket& packet) = 0;
 		virtual void RemoteMuteChangedEvent(const std::string& sid, bool muted) = 0;
+		virtual void LocalTrackUnpublishedEvent(const std::string& sid) = 0;
 		virtual void SpeakersChangedEvent(const std::vector<livekit::SpeakerInfo>& updates) = 0;
 		virtual void RoomUpdateEvent(const livekit::Room& update) = 0;
 		virtual void
@@ -75,6 +76,7 @@ public:
 	webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>
 	CreateSender(LocalTrack* track, TrackPublishOptions options,
 	             std::vector<webrtc::RtpEncodingParameters> send_encodings);
+	bool RemoveSender(LocalTrack* track);
 
 	void PublisherNegotiationNeeded();
 	bool SendDataPacket(const livekit::DataPacket& packet, bool reliable);

--- a/src/core/detail/rtc_session.cpp
+++ b/src/core/detail/rtc_session.cpp
@@ -158,6 +158,13 @@ RtcSession::CreateSender(LocalTrack* track, TrackPublishOptions options,
 	return transceiver;
 }
 
+bool RtcSession::RemoveSender(LocalTrack* track) {
+	if (track == nullptr || publisher_pc_ == nullptr) {
+		return false;
+	}
+	return publisher_pc_->RemoveTrack(track->Transceiver());
+}
+
 void RtcSession::PublisherNegotiationNeeded() {
 	has_published_.store(true);
 	// if (publisher_negotiation_debouncer_->lock()) {

--- a/src/core/detail/rtc_session.h
+++ b/src/core/detail/rtc_session.h
@@ -109,6 +109,7 @@ public:
 	webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>
 	CreateSender(LocalTrack* track, TrackPublishOptions options,
 	             std::vector<webrtc::RtpEncodingParameters> send_encodings);
+	bool RemoveSender(LocalTrack* track);
 
 	void PublisherNegotiationNeeded();
 

--- a/src/core/participant/local_participant.cpp
+++ b/src/core/participant/local_participant.cpp
@@ -25,6 +25,7 @@
 #include "../track/video_source.h"
 #include "../track/video_track.h"
 
+#include "livekit/core/room_event_interface.h"
 #include "livekit_models.pb.h"
 #include "rtc_base/crypto_random.h"
 
@@ -168,13 +169,85 @@ bool LocalParticipant::PublishTrack(LocalTrackInterface* track, TrackPublishOpti
 
 		this->AddTrackPublication(publication);
 
-		local_track->media_track()->set_enabled(true);
+		local_track->SetEnabled(true);
+		if (auto* listener = event_listener_.load()) {
+			listener->OnLocalTrackPublished(publication.get(), this);
+		}
 
 	} catch (const std::exception& e) {
 		std::cout << "publish track error:" << e.what() << std::endl;
 		return false;
 	}
 	return true;
+}
+
+bool LocalParticipant::UnpublishTrack(LocalTrackInterface* track, bool stop_on_unpublish) {
+	if (engine_ == nullptr || track == nullptr) {
+		return false;
+	}
+	auto* local_track = dynamic_cast<LocalTrack*>(track);
+	if (local_track == nullptr || local_track->Sid().empty() || !local_track->Transceiver()) {
+		return false;
+	}
+	auto publications = TrackPublicationsSnapshot();
+	auto publication = publications.find(local_track->Sid());
+	if (publication == publications.end() || publication->second->Track() != local_track ||
+	    !engine_->RemoveSender(local_track)) {
+		return false;
+	}
+
+	local_track->SetTransceiver(nullptr);
+	RemoveTrackPublication(local_track->Sid());
+	if (stop_on_unpublish) {
+		local_track->SetEnabled(false);
+	}
+	engine_->PublisherNegotiationNeeded();
+	if (auto* listener = event_listener_.load()) {
+		listener->OnLocalTrackUnpublished(publication->second.get(), this);
+	}
+	return true;
+}
+
+std::size_t LocalParticipant::UnpublishTracks(const std::vector<LocalTrackInterface*>& tracks,
+                                              bool stop_on_unpublish) {
+	std::size_t unpublished = 0;
+	for (auto* track : tracks) {
+		if (UnpublishTrack(track, stop_on_unpublish)) {
+			++unpublished;
+		}
+	}
+	return unpublished;
+}
+
+bool LocalParticipant::RepublishAllTracks() {
+	struct PendingTrack {
+		LocalTrackInterface* track;
+		TrackPublishOptions options;
+	};
+
+	std::vector<PendingTrack> tracks;
+	for (const auto& [sid, publication] : TrackPublicationsSnapshot()) {
+		auto* local_publication = dynamic_cast<LocalTrackPublication*>(publication.get());
+		auto* local_track = local_publication != nullptr
+		                        ? dynamic_cast<LocalTrackInterface*>(publication->Track())
+		                        : nullptr;
+		if (local_track != nullptr) {
+			tracks.push_back({local_track, local_publication->PublishOptions()});
+		}
+	}
+
+	bool success = true;
+	for (const auto& pending : tracks) {
+		if (!UnpublishTrack(pending.track, false) ||
+		    !PublishTrack(pending.track, pending.options)) {
+			success = false;
+		}
+	}
+	return success;
+}
+
+void LocalParticipant::SetEventListener(RoomEventInterface* listener) {
+	event_listener_.store(listener);
 }
 
 bool LocalParticipant::SetMetadata(const std::string& metadata) {

--- a/src/core/participant/local_participant.h
+++ b/src/core/participant/local_participant.h
@@ -30,8 +30,12 @@
 #include "livekit/core/track/video_media_track_interface.h"
 #include "participant.h"
 
+#include <atomic>
+
 namespace livekit {
 namespace core {
+
+class RoomEventInterface;
 
 class LocalParticipant : public Participant, public LocalParticipantInterface {
 public:
@@ -47,16 +51,22 @@ public:
 	                                           VideoSourceInterface* source) override;
 
 	virtual bool PublishTrack(LocalTrackInterface* track, TrackPublishOptions option) override;
+	bool UnpublishTrack(LocalTrackInterface* track, bool stop_on_unpublish) override;
+	std::size_t UnpublishTracks(const std::vector<LocalTrackInterface*>& tracks,
+	                            bool stop_on_unpublish) override;
+	bool RepublishAllTracks() override;
 	bool SetMetadata(const std::string& metadata) override;
 	bool SetName(const std::string& name) override;
 	bool SetAttributes(const std::map<std::string, std::string>& attributes) override;
 	bool PublishData(const std::vector<uint8_t>& data, DataPublishOptions options) override;
 	bool SendFile(const std::string& path, FileSendOptions options) override;
+	void SetEventListener(RoomEventInterface* listener);
 
 private:
 	RtcEngine* engine_;
 	RoomOptions options_;
 	EncryptionType encryption_type_;
+	std::atomic<RoomEventInterface*> event_listener_{nullptr};
 
 	// AudioSourceInterface* source_;
 };

--- a/src/core/room.cpp
+++ b/src/core/room.cpp
@@ -130,9 +130,15 @@ bool Room::Connect(std::string url, std::string token, RoomConnectOptions opts) 
 	return true;
 }
 
-void Room::AddEventListener(RoomEventInterface* listener) { event_listener_.store(listener); }
+void Room::AddEventListener(RoomEventInterface* listener) {
+	event_listener_.store(listener);
+	local_participant_->SetEventListener(listener);
+}
 
-void Room::RemoveEventListener() { event_listener_.store(nullptr); }
+void Room::RemoveEventListener() {
+	local_participant_->SetEventListener(nullptr);
+	event_listener_.store(nullptr);
+}
 
 bool Room::IsConnected() { return state_.load() == RoomState::Connected; }
 
@@ -359,6 +365,26 @@ void Room::RemoteMuteChangedEvent(const std::string& sid, bool muted) {
 		} else {
 			listener->OnTrackUnmuted(publication.get(), participant.get());
 		}
+	}
+}
+
+void Room::LocalTrackUnpublishedEvent(const std::string& sid) {
+	auto publications = local_participant_->TrackPublicationsSnapshot();
+	auto found = publications.find(sid);
+	if (found == publications.end()) {
+		return;
+	}
+	auto publication = found->second;
+	if (auto* local_track = dynamic_cast<LocalTrack*>(publication->Track())) {
+		if (local_participant_->UnpublishTrack(local_track, true)) {
+			return;
+		}
+		local_track->SetTransceiver(nullptr);
+		local_track->SetEnabled(false);
+	}
+	local_participant_->RemoveTrackPublication(sid);
+	if (auto* listener = event_listener_.load()) {
+		listener->OnLocalTrackUnpublished(publication.get(), local_participant_.get());
 	}
 }
 

--- a/src/core/room.h
+++ b/src/core/room.h
@@ -71,6 +71,7 @@ public:
 	void MediaTrackEvent(webrtc::scoped_refptr<webrtc::MediaStreamTrackInterface> track) override;
 	void DataPacketEvent(const livekit::DataPacket& packet) override;
 	void RemoteMuteChangedEvent(const std::string& sid, bool muted) override;
+	void LocalTrackUnpublishedEvent(const std::string& sid) override;
 	void SpeakersChangedEvent(const std::vector<livekit::SpeakerInfo>& updates) override;
 	void RoomUpdateEvent(const livekit::Room& update) override;
 	void

--- a/src/core/track/local_track.cpp
+++ b/src/core/track/local_track.cpp
@@ -23,5 +23,16 @@ LocalTrack::LocalTrack(std::string sid, std::string name, TrackKind kind,
                        std::unique_ptr<MediaStreamTrack> meida_track)
     : meida_track_(std::move(meida_track)), Track(sid, name, kind) {}
 
+void LocalTrack::SetEnabled(bool enabled) {
+	Track::SetEnabled(enabled);
+	if (meida_track_ != nullptr) {
+		meida_track_->set_enabled(enabled);
+	}
+}
+
+bool LocalTrack::IsEnabled() {
+	return Track::IsEnabled() && meida_track_ != nullptr && meida_track_->enabled();
+}
+
 } // namespace core
 } // namespace livekit

--- a/src/core/track/local_track.h
+++ b/src/core/track/local_track.h
@@ -35,6 +35,8 @@ public:
 	virtual ~LocalTrack() = default;
 
 	MediaStreamTrack* media_track() const { return meida_track_.get(); }
+	void SetEnabled(bool enabled) override;
+	bool IsEnabled() override;
 
 private:
 	std::unique_ptr<MediaStreamTrack> meida_track_;

--- a/src/core/track/local_track_publication.cpp
+++ b/src/core/track/local_track_publication.cpp
@@ -24,8 +24,13 @@ LocalTrackPublication::LocalTrackPublication(livekit::TrackInfo info, LocalTrack
     : TrackPublication(info, track) {}
 
 void LocalTrackPublication::UpdatePublishOptions(TrackPublishOptions option) {
+	std::lock_guard<std::mutex> guard(option_mutex_);
 	option_ = option;
-	return;
+}
+
+TrackPublishOptions LocalTrackPublication::PublishOptions() const {
+	std::lock_guard<std::mutex> guard(option_mutex_);
+	return option_;
 }
 
 } // namespace core

--- a/src/core/track/local_track_publication.h
+++ b/src/core/track/local_track_publication.h
@@ -36,8 +36,10 @@ public:
 	virtual ~LocalTrackPublication() override = default;
 
 	void UpdatePublishOptions(TrackPublishOptions option);
+	TrackPublishOptions PublishOptions() const;
 
 private:
+	mutable std::mutex option_mutex_;
 	TrackPublishOptions option_;
 };
 

--- a/src/core/track/remote_track.cpp
+++ b/src/core/track/remote_track.cpp
@@ -24,5 +24,16 @@ RemoteTrack::RemoteTrack(std::string sid, std::string name, TrackKind kind,
                          std::unique_ptr<MediaStreamTrack> media_track)
     : Track(std::move(sid), std::move(name), kind), media_track_(std::move(media_track)) {}
 
+void RemoteTrack::SetEnabled(bool enabled) {
+	Track::SetEnabled(enabled);
+	if (media_track_ != nullptr) {
+		media_track_->set_enabled(enabled);
+	}
+}
+
+bool RemoteTrack::IsEnabled() {
+	return Track::IsEnabled() && media_track_ != nullptr && media_track_->enabled();
+}
+
 } // namespace core
 } // namespace livekit

--- a/src/core/track/remote_track.h
+++ b/src/core/track/remote_track.h
@@ -34,6 +34,8 @@ public:
 	~RemoteTrack() override = default;
 
 	MediaStreamTrack* media_track() const { return media_track_.get(); }
+	void SetEnabled(bool enabled) override;
+	bool IsEnabled() override;
 
 private:
 	std::unique_ptr<MediaStreamTrack> media_track_;

--- a/src/core/track/track.cpp
+++ b/src/core/track/track.cpp
@@ -41,8 +41,8 @@ bool Track::Muted() { return muted_.load(); };
 void Track::SetMuted(bool muted) { muted_.store(muted); };
 
 std::string Track::GetRTCStats() { return ""; };
-void Track::Track::SetEnabled(bool enabled) {};
-bool Track::IsEnabled() { return true; };
+void Track::SetEnabled(bool enabled) { enabled_.store(enabled); };
+bool Track::IsEnabled() { return enabled_.load(); };
 
 void Track::UpdateInfo(livekit::TrackInfo info) {
 	info_ = info;
@@ -53,7 +53,13 @@ void Track::UpdateInfo(livekit::TrackInfo info) {
 }
 
 void Track::SetTransceiver(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver) {
+	std::lock_guard<std::mutex> guard(transceiver_mutex_);
 	transceiver_ = transceiver;
+}
+
+webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> Track::Transceiver() const {
+	std::lock_guard<std::mutex> guard(transceiver_mutex_);
+	return transceiver_;
 }
 
 } // namespace core

--- a/src/core/track/track.h
+++ b/src/core/track/track.h
@@ -27,6 +27,7 @@
 #include <api/rtp_transceiver_interface.h>
 
 #include <atomic>
+#include <mutex>
 
 namespace livekit {
 namespace core {
@@ -53,6 +54,7 @@ public:
 	void UpdateInfo(livekit::TrackInfo info);
 
 	void SetTransceiver(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver);
+	webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> Transceiver() const;
 
 private:
 	livekit::TrackInfo info_;
@@ -63,6 +65,8 @@ private:
 	TrackStreamState stream_state_;
 	TrackDimensions dimensions_;
 	std::atomic<bool> muted_{false};
+	std::atomic<bool> enabled_{true};
+	mutable std::mutex transceiver_mutex_;
 	webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver_;
 };
 } // namespace core

--- a/test/functional/c_api_test.cpp
+++ b/test/functional/c_api_test.cpp
@@ -48,6 +48,8 @@ TEST(CApiTest, ValidatesArgumentsWithoutThrowingAcrossAbi) {
 	EXPECT_EQ(lk_audio_source_capture_frame(nullptr, nullptr, 0), LK_STATUS_INVALID_ARGUMENT);
 	EXPECT_EQ(lk_video_source_capture_i420(nullptr, nullptr, 0, 0, 0, 0),
 	          LK_STATUS_INVALID_ARGUMENT);
+	EXPECT_EQ(lk_local_track_unpublish(nullptr, 1), LK_STATUS_INVALID_ARGUMENT);
+	EXPECT_EQ(lk_room_republish_all_tracks(nullptr), LK_STATUS_INVALID_ARGUMENT);
 }
 
 TEST(CApiTest, CreatesRoomAndCapturesLocalFrames) {
@@ -62,6 +64,8 @@ TEST(CApiTest, CreatesRoomAndCapturesLocalFrames) {
 
 	lk_room_callbacks_t callbacks;
 	lk_room_callbacks_init(&callbacks);
+	EXPECT_EQ(callbacks.on_local_track_published, nullptr);
+	EXPECT_EQ(callbacks.on_local_track_unpublished, nullptr);
 	EXPECT_EQ(lk_room_set_callbacks(room, &callbacks), LK_STATUS_OK);
 	EXPECT_EQ(lk_room_set_callbacks(room, nullptr), LK_STATUS_OK);
 	EXPECT_EQ(lk_room_set_remote_track_subscribed(room, "missing", "missing", 1),

--- a/test/functional/participant_state_test.cpp
+++ b/test/functional/participant_state_test.cpp
@@ -1,5 +1,7 @@
 #include "../../src/core/participant/remote_participant.h"
 #include "../../src/core/room.h"
+#include "../../src/core/track/track.h"
+#include "../../src/core/track/track_publication.h"
 
 #include "livekit_models.pb.h"
 
@@ -115,6 +117,54 @@ TEST(ParticipantStateTest, FindsRemoteParticipantByIdentity) {
 	EXPECT_EQ(participant->Sid(), "PA_remote");
 	EXPECT_EQ(room.GetParticipantByIdentity("remote-identity"), participant);
 	EXPECT_EQ(room.GetRemoteParticipantByIdentity("Remote User"), nullptr);
+}
+
+TEST(TrackStateTest, ReportsEnabledStateChanges) {
+	Track track("TR_local", "camera", TrackKind::Video);
+	EXPECT_TRUE(track.IsEnabled());
+	track.SetEnabled(false);
+	EXPECT_FALSE(track.IsEnabled());
+	track.SetEnabled(true);
+	EXPECT_TRUE(track.IsEnabled());
+}
+
+class LocalTrackEvents final : public RoomEventInterface {
+public:
+	void OnConnected() override {}
+
+	void OnLocalTrackUnpublished(TrackPublicationInterface* publication,
+	                             ParticipantInterface* participant) override {
+		++unpublished_count;
+		track_sid = publication != nullptr ? publication->Sid() : "";
+		participant_is_local = participant != nullptr && participant->IsLocalParticipant();
+	}
+
+	int unpublished_count = 0;
+	std::string track_sid;
+	bool participant_is_local = false;
+};
+
+TEST(LocalTrackStateTest, HandlesServerInitiatedUnpublishOnce) {
+	Room room;
+	LocalTrackEvents events;
+	room.AddEventListener(&events);
+
+	livekit::TrackInfo info = MakeTrack("TR_local", "camera", livekit::TrackType::VIDEO,
+	                                    livekit::TrackSource::CAMERA, false);
+	auto publication = std::make_shared<TrackPublication>(info, nullptr);
+	auto* participant = dynamic_cast<LocalParticipant*>(room.GetLocalParticipant());
+	ASSERT_NE(participant, nullptr);
+	participant->AddTrackPublication(publication);
+
+	room.LocalTrackUnpublishedEvent("TR_local");
+	EXPECT_EQ(events.unpublished_count, 1);
+	EXPECT_EQ(events.track_sid, "TR_local");
+	EXPECT_TRUE(events.participant_is_local);
+	EXPECT_EQ(participant->GetTrackPublicationByName("camera"), nullptr);
+
+	room.LocalTrackUnpublishedEvent("TR_local");
+	EXPECT_EQ(events.unpublished_count, 1);
+	room.RemoveEventListener();
 }
 
 } // namespace

--- a/test/integration/livekit_server_test.cpp
+++ b/test/integration/livekit_server_test.cpp
@@ -75,6 +75,14 @@ public:
 		}
 	}
 
+	void OnLocalTrackPublished(TrackPublicationInterface*, ParticipantInterface*) override {
+		local_tracks_published_.fetch_add(1);
+	}
+
+	void OnLocalTrackUnpublished(TrackPublicationInterface*, ParticipantInterface*) override {
+		local_tracks_unpublished_.fetch_add(1);
+	}
+
 	void OnAudioFrame(RemoteTrackInterface*, RemoteParticipantInterface*,
 	                  const AudioFrame& frame) override {
 		if (!frame.data.empty() && frame.sample_rate > 0 && frame.num_channels > 0) {
@@ -113,6 +121,8 @@ public:
 	uint64_t video_frame_count() const { return video_frames_.load(); }
 	uint32_t last_video_width() const { return last_video_width_.load(); }
 	uint32_t last_video_height() const { return last_video_height_.load(); }
+	uint64_t local_tracks_published() const { return local_tracks_published_.load(); }
+	uint64_t local_tracks_unpublished() const { return local_tracks_unpublished_.load(); }
 	bool received_data(const std::string& topic, const std::vector<uint8_t>& expected,
 	                   bool reliable) {
 		std::lock_guard<std::mutex> guard(lock_);
@@ -132,6 +142,8 @@ private:
 	std::atomic<uint64_t> video_frames_{0};
 	std::atomic<uint32_t> last_video_width_{0};
 	std::atomic<uint32_t> last_video_height_{0};
+	std::atomic<uint64_t> local_tracks_published_{0};
+	std::atomic<uint64_t> local_tracks_unpublished_{0};
 	std::mutex lock_;
 	std::string data_topic_;
 	std::vector<uint8_t> data_;
@@ -336,6 +348,7 @@ TEST(LiveKitServerTest, PublishesAndReceivesAudioAndVideo) {
 	auto receiver = CreateRoomUnique();
 	auto sender = CreateRoomUnique();
 	receiver->AddEventListener(&events);
+	sender->AddEventListener(&events);
 	ASSERT_TRUE(receiver->Connect(url, receiver_token));
 	ASSERT_TRUE(sender->Connect(url, sender_token));
 	ASSERT_TRUE(WaitUntil([&] { return receiver->IsConnected() && sender->IsConnected(); },
@@ -423,11 +436,29 @@ TEST(LiveKitServerTest, PublishesAndReceivesAudioAndVideo) {
 	EXPECT_EQ(video_publication->Kind(), TrackKind::Video);
 	EXPECT_TRUE(sender_participant->IsCameraEnabled());
 
+	std::vector<LocalTrackInterface*> video_tracks{video_track.get()};
+	ASSERT_EQ(sender->GetLocalParticipant()->UnpublishTracks(video_tracks, false), 1u);
+	EXPECT_TRUE(video_track->IsEnabled());
+	ASSERT_TRUE(WaitUntil(
+	    [&] { return sender_participant->GetTrackPublication(TrackSource::Camera) == nullptr; }));
+	ASSERT_TRUE(sender->GetLocalParticipant()->RepublishAllTracks());
+	ASSERT_TRUE(WaitUntil([&] {
+		return sender_participant->GetTrackPublication(TrackSource::Microphone) != nullptr;
+	}));
+	EXPECT_GE(events.local_tracks_published(), 3u);
+	EXPECT_GE(events.local_tracks_unpublished(), 2u);
+	ASSERT_TRUE(sender->GetLocalParticipant()->UnpublishTrack(audio_track.get()));
+	EXPECT_FALSE(audio_track->IsEnabled());
+	ASSERT_TRUE(WaitUntil([&] {
+		return sender_participant->GetTrackPublication(TrackSource::Microphone) == nullptr;
+	}));
+
 	video_track.reset();
 	video_source.reset();
 	audio_track.reset();
 	audio_source.reset();
 	receiver->RemoveEventListener();
+	sender->RemoveEventListener();
 	EXPECT_TRUE(sender->Disconnect());
 	EXPECT_TRUE(receiver->Disconnect());
 }


### PR DESCRIPTION
Align the C++ and C APIs with the official SDK local track lifecycle, including batch unpublish, republish, local events, and server-triggered cleanup.

Validated with the VS2022 x64 Release build and 33 unit/functional tests. Integration tests compile and skip when LiveKit credentials are absent.