### PR TITLE
feat: add text and byte data streams

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -97,7 +97,7 @@ the server URL and short-lived tokens in the environment:
 
 - `LIVEKIT_TOKEN_SINGLE`: a unique identity for the single-client lifecycle test.
 - `LIVEKIT_TOKEN` and `LIVEKIT_TOKEN_2`: two different identities in the same room for the
-  participant, audio, video, data-message, and file-transfer tests.
+  participant, audio, video, data-message, text/byte-stream, and file-transfer tests.
 - `LIVEKIT_TOKEN_2_UPDATE` (optional): replaces `LIVEKIT_TOKEN_2` in the participant-state test
   and must be generated with `lk create-token --allow-update-metadata`; when omitted,
   metadata/name/attribute update checks are skipped.

--- a/examples/README.md
+++ b/examples/README.md
@@ -109,7 +109,8 @@ same operation as `lk_room_republish_all_tracks()`.
 
 ### `data_transfer`
 
-Sends a reliable data message followed by the selected file as a chunked LiveKit data stream.
+Sends text, in-memory bytes, and the selected file using LiveKit data streams compatible with the
+official JS and Go SDKs.
 
 ```powershell
 & "out/build/vs2022-x64-release/examples/data_transfer/Release/data_transfer.exe" `
@@ -139,4 +140,4 @@ token, then run one of the publishing examples in another terminal:
 ```
 
 The receiver reports track subscription and the first decoded audio or video frame. For
-`data_transfer`, it reports both the data message and the completed file size.
+`data_transfer`, it reports the text stream, byte stream, and completed file size.

--- a/examples/data_transfer/data_transfer.cpp
+++ b/examples/data_transfer/data_transfer.cpp
@@ -40,13 +40,16 @@ int main(int argc, char* argv[]) {
 		return 1;
 	}
 
-	livekit::core::DataPublishOptions message_options;
-	message_options.topic = "file-transfer";
+	livekit::core::TextSendOptions message_options;
+	message_options.topic = "text-transfer";
 	const std::string message = "sending:" + path.filename().string();
-	if (!room->GetLocalParticipant()->PublishData(
-	        std::vector<uint8_t>(message.begin(), message.end()), message_options) ||
+	const std::vector<uint8_t> bytes{'l', 'i', 'v', 'e', 'k', 'i', 't'};
+	livekit::core::ByteSendOptions byte_options;
+	byte_options.topic = "byte-transfer";
+	if (!room->GetLocalParticipant()->SendText(message, message_options) ||
+	    !room->GetLocalParticipant()->SendBytes(bytes, byte_options) ||
 	    !room->GetLocalParticipant()->SendFile(path.string())) {
-		std::cerr << "Failed to send file" << std::endl;
+		std::cerr << "Failed to send data streams" << std::endl;
 		return 1;
 	}
 

--- a/examples/room_event/room_event.cpp
+++ b/examples/room_event/room_event.cpp
@@ -48,6 +48,16 @@ public:
 		          << ", from=" << event.participant_identity << std::endl;
 	}
 
+	void OnTextReceived(const livekit::core::TextReceivedEvent& event) override {
+		std::cout << "Text received: topic=" << event.topic << ", text=" << event.text
+		          << ", from=" << event.participant_identity << std::endl;
+	}
+
+	void OnByteReceived(const livekit::core::ByteReceivedEvent& event) override {
+		std::cout << "Bytes received: topic=" << event.topic << ", bytes=" << event.data.size()
+		          << ", from=" << event.participant_identity << std::endl;
+	}
+
 	void OnFileReceived(const livekit::core::FileReceivedEvent& event) override {
 		std::cout << "File received: " << event.name << " (" << event.data.size() << " bytes)"
 		          << std::endl;

--- a/include/livekit/capi/livekit.h
+++ b/include/livekit/capi/livekit.h
@@ -133,6 +133,15 @@ typedef struct lk_file_received {
 	const char* participant_identity;
 } lk_file_received_t;
 
+typedef struct lk_text_received {
+	const char* stream_id;
+	const char* text;
+	const char* topic;
+	const char* participant_identity;
+	const char* reply_to_stream_id;
+	int64_t timestamp;
+} lk_text_received_t;
+
 typedef struct lk_attribute {
 	const char* key;
 	const char* value;
@@ -156,6 +165,8 @@ typedef void (*lk_data_received_callback)(void* user_data, lk_room_t* room,
                                           const lk_data_received_t* event);
 typedef void (*lk_file_received_callback)(void* user_data, lk_room_t* room,
                                           const lk_file_received_t* event);
+typedef void (*lk_text_received_callback)(void* user_data, lk_room_t* room,
+                                          const lk_text_received_t* event);
 typedef void (*lk_room_metadata_callback)(void* user_data, lk_room_t* room, const char* metadata);
 typedef void (*lk_connection_quality_callback)(void* user_data, lk_room_t* room,
                                                lk_connection_quality_t quality,
@@ -185,6 +196,8 @@ typedef struct lk_room_callbacks {
 	lk_active_speakers_callback on_active_speakers_changed;
 	lk_track_event_callback on_local_track_published;
 	lk_track_event_callback on_local_track_unpublished;
+	lk_text_received_callback on_text_received;
+	lk_file_received_callback on_byte_received;
 } lk_room_callbacks_t;
 
 typedef struct lk_audio_source_options {
@@ -226,7 +239,34 @@ typedef struct lk_file_send_options {
 	const char* const* destination_identities;
 	size_t destination_identity_count;
 	size_t chunk_size;
+	const lk_attribute_t* attributes;
+	size_t attribute_count;
 } lk_file_send_options_t;
+
+typedef struct lk_text_send_options {
+	size_t struct_size;
+	const char* topic;
+	const char* const* destination_identities;
+	size_t destination_identity_count;
+	const lk_attribute_t* attributes;
+	size_t attribute_count;
+	const char* reply_to_stream_id;
+	const char* const* attached_stream_ids;
+	size_t attached_stream_id_count;
+	size_t chunk_size;
+} lk_text_send_options_t;
+
+typedef struct lk_byte_send_options {
+	size_t struct_size;
+	const char* topic;
+	const char* mime_type;
+	const char* name;
+	const char* const* destination_identities;
+	size_t destination_identity_count;
+	const lk_attribute_t* attributes;
+	size_t attribute_count;
+	size_t chunk_size;
+} lk_byte_send_options_t;
 
 LKC_API lk_status_t lk_init(void);
 LKC_API lk_status_t lk_shutdown(void);
@@ -239,6 +279,8 @@ LKC_API void lk_video_source_options_init(lk_video_source_options_t* options);
 LKC_API void lk_track_publish_options_init(lk_track_publish_options_t* options);
 LKC_API void lk_data_publish_options_init(lk_data_publish_options_t* options);
 LKC_API void lk_file_send_options_init(lk_file_send_options_t* options);
+LKC_API void lk_text_send_options_init(lk_text_send_options_t* options);
+LKC_API void lk_byte_send_options_init(lk_byte_send_options_t* options);
 
 LKC_API lk_status_t lk_room_create(lk_room_t** room);
 LKC_API void lk_room_destroy(lk_room_t* room);
@@ -293,6 +335,10 @@ LKC_API lk_status_t lk_room_set_remote_track_subscribed(lk_room_t* room,
 
 LKC_API lk_status_t lk_room_publish_data(lk_room_t* room, const uint8_t* data, size_t data_size,
                                          const lk_data_publish_options_t* options);
+LKC_API lk_status_t lk_room_send_text(lk_room_t* room, const char* text,
+                                      const lk_text_send_options_t* options);
+LKC_API lk_status_t lk_room_send_bytes(lk_room_t* room, const uint8_t* data, size_t data_size,
+                                       const lk_byte_send_options_t* options);
 LKC_API lk_status_t lk_room_send_file(lk_room_t* room, const char* path,
                                       const lk_file_send_options_t* options);
 

--- a/include/livekit/core/data_packet.h
+++ b/include/livekit/core/data_packet.h
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -29,6 +30,36 @@ struct FileSendOptions {
 	std::string mime_type = "application/octet-stream";
 	std::vector<std::string> destination_identities;
 	std::size_t chunk_size = 15'000;
+	std::map<std::string, std::string> attributes;
+};
+
+struct TextSendOptions {
+	std::string topic;
+	std::vector<std::string> destination_identities;
+	std::map<std::string, std::string> attributes;
+	std::string reply_to_stream_id;
+	std::vector<std::string> attached_stream_ids;
+	std::size_t chunk_size = 15'000;
+};
+
+struct ByteSendOptions {
+	std::string topic;
+	std::string mime_type = "application/octet-stream";
+	std::string name;
+	std::vector<std::string> destination_identities;
+	std::map<std::string, std::string> attributes;
+	std::size_t chunk_size = 15'000;
+};
+
+struct TextReceivedEvent {
+	std::string stream_id;
+	std::string text;
+	std::string topic;
+	std::string participant_identity;
+	std::string reply_to_stream_id;
+	std::vector<std::string> attached_stream_ids;
+	std::map<std::string, std::string> attributes;
+	int64_t timestamp = 0;
 };
 
 struct FileReceivedEvent {
@@ -38,7 +69,11 @@ struct FileReceivedEvent {
 	std::string topic;
 	std::string participant_identity;
 	std::vector<uint8_t> data;
+	std::map<std::string, std::string> attributes;
+	int64_t timestamp = 0;
 };
+
+struct ByteReceivedEvent : FileReceivedEvent {};
 
 } // namespace core
 } // namespace livekit

--- a/include/livekit/core/participant/local_participant_interface.h
+++ b/include/livekit/core/participant/local_participant_interface.h
@@ -73,6 +73,8 @@ public:
 	virtual bool SetName(const std::string&) { return false; }
 	virtual bool SetAttributes(const std::map<std::string, std::string>&) { return false; }
 	virtual bool PublishData(const std::vector<uint8_t>& data, DataPublishOptions options = {}) = 0;
+	virtual bool SendText(const std::string& text, TextSendOptions options = {}) = 0;
+	virtual bool SendBytes(const std::vector<uint8_t>& data, ByteSendOptions options = {}) = 0;
 	virtual bool SendFile(const std::string& path, FileSendOptions options = {}) = 0;
 };
 

--- a/include/livekit/core/room_event_interface.h
+++ b/include/livekit/core/room_event_interface.h
@@ -64,6 +64,8 @@ public:
 	virtual void OnVideoFrame(RemoteTrackInterface*, RemoteParticipantInterface*,
 	                          const VideoFrame&) {}
 	virtual void OnDataReceived(const DataReceivedEvent&) {}
+	virtual void OnTextReceived(const TextReceivedEvent&) {}
+	virtual void OnByteReceived(const ByteReceivedEvent&) {}
 	virtual void OnFileReceived(const FileReceivedEvent&) {}
 };
 

--- a/src/capi/livekit.cpp
+++ b/src/capi/livekit.cpp
@@ -311,6 +311,20 @@ std::vector<std::string> DestinationIdentities(const char* const* identities, si
 	return result;
 }
 
+bool CopyAttributes(const lk_attribute_t* attributes, size_t count,
+                    std::map<std::string, std::string>& result) {
+	if (count != 0 && attributes == nullptr) {
+		return false;
+	}
+	for (size_t index = 0; index < count; ++index) {
+		if (attributes[index].key == nullptr || attributes[index].value == nullptr) {
+			return false;
+		}
+		result[attributes[index].key] = attributes[index].value;
+	}
+	return true;
+}
+
 } // namespace
 
 class CRoomEvents final : public core::RoomEventInterface {
@@ -429,7 +443,31 @@ public:
 		});
 	}
 
+	void OnTextReceived(const core::TextReceivedEvent& event) override {
+		const lk_text_received_t c_event{event.stream_id.c_str(),
+		                                 event.text.c_str(),
+		                                 event.topic.c_str(),
+		                                 event.participant_identity.c_str(),
+		                                 event.reply_to_stream_id.c_str(),
+		                                 event.timestamp};
+		InvokeRoomCallback(owner_, [&](const lk_room_callbacks_t& callbacks) {
+			if (callbacks.on_text_received != nullptr) {
+				callbacks.on_text_received(callbacks.user_data, owner_, &c_event);
+			}
+		});
+	}
+
+	void OnByteReceived(const core::ByteReceivedEvent& event) override {
+		File(callbacks_member(&lk_room_callbacks_t::on_byte_received), event);
+	}
+
 	void OnFileReceived(const core::FileReceivedEvent& event) override {
+		File(callbacks_member(&lk_room_callbacks_t::on_file_received), event);
+	}
+
+private:
+	void File(lk_file_received_callback lk_room_callbacks_t::*callback,
+	          const core::FileReceivedEvent& event) {
 		const lk_file_received_t c_event{event.data.data(),
 		                                 event.data.size(),
 		                                 event.stream_id.c_str(),
@@ -438,12 +476,13 @@ public:
 		                                 event.topic.c_str(),
 		                                 event.participant_identity.c_str()};
 		InvokeRoomCallback(owner_, [&](const lk_room_callbacks_t& callbacks) {
-			if (callbacks.on_file_received != nullptr) {
-				callbacks.on_file_received(callbacks.user_data, owner_, &c_event);
+			if (callbacks.*callback != nullptr) {
+				(callbacks.*callback)(callbacks.user_data, owner_, &c_event);
 			}
 		});
 	}
 
+public:
 	void OnRoomMetadataChanged(const std::string& metadata) override {
 		InvokeRoomCallback(owner_, [&](const lk_room_callbacks_t& callbacks) {
 			if (callbacks.on_room_metadata_changed != nullptr) {
@@ -598,6 +637,23 @@ void lk_file_send_options_init(lk_file_send_options_t* options) {
 		*options = {};
 		options->struct_size = sizeof(*options);
 		options->topic = "files";
+		options->mime_type = "application/octet-stream";
+		options->chunk_size = 15000;
+	}
+}
+
+void lk_text_send_options_init(lk_text_send_options_t* options) {
+	if (options != nullptr) {
+		*options = {};
+		options->struct_size = sizeof(*options);
+		options->chunk_size = 15000;
+	}
+}
+
+void lk_byte_send_options_init(lk_byte_send_options_t* options) {
+	if (options != nullptr) {
+		*options = {};
+		options->struct_size = sizeof(*options);
 		options->mime_type = "application/octet-stream";
 		options->chunk_size = 15000;
 	}
@@ -1154,6 +1210,107 @@ lk_status_t lk_room_publish_data(lk_room_t* room, const uint8_t* data, size_t da
 	});
 }
 
+lk_status_t lk_room_send_text(lk_room_t* room, const char* text,
+                              const lk_text_send_options_t* options) {
+	return Guard([&] {
+		auto* participant = LocalParticipant(room);
+		if (participant == nullptr || text == nullptr) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "room and text are required");
+		}
+		core::TextSendOptions send_options;
+		if (options != nullptr) {
+			if (options->struct_size < sizeof(options->struct_size)) {
+				return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid text options struct size");
+			}
+			if (LKC_HAS_FIELD(options, lk_text_send_options_t, topic) &&
+			    options->topic != nullptr) {
+				send_options.topic = options->topic;
+			}
+			if (LKC_HAS_FIELD(options, lk_text_send_options_t, destination_identity_count)) {
+				if (options->destination_identity_count != 0 &&
+				    options->destination_identities == nullptr) {
+					return Failure(LK_STATUS_INVALID_ARGUMENT, "destination identities are null");
+				}
+				send_options.destination_identities = DestinationIdentities(
+				    options->destination_identities, options->destination_identity_count);
+			}
+			if (LKC_HAS_FIELD(options, lk_text_send_options_t, attribute_count) &&
+			    !CopyAttributes(options->attributes, options->attribute_count,
+			                    send_options.attributes)) {
+				return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid text attributes");
+			}
+			if (LKC_HAS_FIELD(options, lk_text_send_options_t, reply_to_stream_id) &&
+			    options->reply_to_stream_id != nullptr) {
+				send_options.reply_to_stream_id = options->reply_to_stream_id;
+			}
+			if (LKC_HAS_FIELD(options, lk_text_send_options_t, attached_stream_id_count)) {
+				if (options->attached_stream_id_count != 0 &&
+				    options->attached_stream_ids == nullptr) {
+					return Failure(LK_STATUS_INVALID_ARGUMENT, "attached stream IDs are null");
+				}
+				send_options.attached_stream_ids = DestinationIdentities(
+				    options->attached_stream_ids, options->attached_stream_id_count);
+			}
+			if (LKC_HAS_FIELD(options, lk_text_send_options_t, chunk_size)) {
+				send_options.chunk_size = options->chunk_size;
+			}
+		}
+		return participant->SendText(text, std::move(send_options))
+		           ? LK_STATUS_OK
+		           : Failure(LK_STATUS_OPERATION_FAILED, "failed to send text stream");
+	});
+}
+
+lk_status_t lk_room_send_bytes(lk_room_t* room, const uint8_t* data, size_t data_size,
+                               const lk_byte_send_options_t* options) {
+	return Guard([&] {
+		auto* participant = LocalParticipant(room);
+		if (participant == nullptr || (data == nullptr && data_size != 0)) {
+			return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid room or byte buffer");
+		}
+		core::ByteSendOptions send_options;
+		if (options != nullptr) {
+			if (options->struct_size < sizeof(options->struct_size)) {
+				return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid byte options struct size");
+			}
+			if (LKC_HAS_FIELD(options, lk_byte_send_options_t, topic) &&
+			    options->topic != nullptr) {
+				send_options.topic = options->topic;
+			}
+			if (LKC_HAS_FIELD(options, lk_byte_send_options_t, mime_type) &&
+			    options->mime_type != nullptr) {
+				send_options.mime_type = options->mime_type;
+			}
+			if (LKC_HAS_FIELD(options, lk_byte_send_options_t, name) && options->name != nullptr) {
+				send_options.name = options->name;
+			}
+			if (LKC_HAS_FIELD(options, lk_byte_send_options_t, destination_identity_count)) {
+				if (options->destination_identity_count != 0 &&
+				    options->destination_identities == nullptr) {
+					return Failure(LK_STATUS_INVALID_ARGUMENT, "destination identities are null");
+				}
+				send_options.destination_identities = DestinationIdentities(
+				    options->destination_identities, options->destination_identity_count);
+			}
+			if (LKC_HAS_FIELD(options, lk_byte_send_options_t, attribute_count) &&
+			    !CopyAttributes(options->attributes, options->attribute_count,
+			                    send_options.attributes)) {
+				return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid byte attributes");
+			}
+			if (LKC_HAS_FIELD(options, lk_byte_send_options_t, chunk_size)) {
+				send_options.chunk_size = options->chunk_size;
+			}
+		}
+		std::vector<uint8_t> payload;
+		if (data_size != 0) {
+			payload.assign(data, data + data_size);
+		}
+		return participant->SendBytes(payload, std::move(send_options))
+		           ? LK_STATUS_OK
+		           : Failure(LK_STATUS_OPERATION_FAILED, "failed to send byte stream");
+	});
+}
+
 lk_status_t lk_room_send_file(lk_room_t* room, const char* path,
                               const lk_file_send_options_t* options) {
 	return Guard([&] {
@@ -1184,6 +1341,11 @@ lk_status_t lk_room_send_file(lk_room_t* room, const char* path,
 			}
 			if (LKC_HAS_FIELD(options, lk_file_send_options_t, chunk_size)) {
 				send_options.chunk_size = options->chunk_size;
+			}
+			if (LKC_HAS_FIELD(options, lk_file_send_options_t, attribute_count) &&
+			    !CopyAttributes(options->attributes, options->attribute_count,
+			                    send_options.attributes)) {
+				return Failure(LK_STATUS_INVALID_ARGUMENT, "invalid file attributes");
 			}
 		}
 		return participant->SendFile(path, std::move(send_options))

--- a/src/core/participant/local_participant.cpp
+++ b/src/core/participant/local_participant.cpp
@@ -29,6 +29,7 @@
 #include "livekit_models.pb.h"
 #include "rtc_base/crypto_random.h"
 
+#include <algorithm>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -36,6 +37,65 @@
 
 namespace livekit {
 namespace core {
+
+namespace {
+
+constexpr std::size_t kMaximumDataStreamChunkSize = 15'000;
+
+int64_t CurrentTimestampMilliseconds() {
+	return std::chrono::duration_cast<std::chrono::milliseconds>(
+	           std::chrono::system_clock::now().time_since_epoch())
+	    .count();
+}
+
+template <typename Options>
+void PopulateStreamPacket(livekit::DataPacket& packet, const Options& options) {
+	for (const auto& identity : options.destination_identities) {
+		packet.add_destination_identities(identity);
+	}
+}
+
+template <typename Options>
+void PopulateStreamHeader(livekit::DataStream_Header& header, const std::string& stream_id,
+                          uint64_t total_length, const Options& options) {
+	header.set_stream_id(stream_id);
+	header.set_timestamp(CurrentTimestampMilliseconds());
+	header.set_topic(options.topic);
+	header.set_total_length(total_length);
+	for (const auto& [key, value] : options.attributes) {
+		(*header.mutable_attributes())[key] = value;
+	}
+}
+
+template <typename Options>
+bool SendStreamPayload(RtcEngine* engine, const std::string& stream_id, const uint8_t* data,
+                       std::size_t size, const Options& options) {
+	if (engine == nullptr || options.chunk_size == 0 ||
+	    options.chunk_size > kMaximumDataStreamChunkSize || (data == nullptr && size != 0)) {
+		return false;
+	}
+	uint64_t chunk_index = 0;
+	for (std::size_t offset = 0; offset < size; offset += options.chunk_size) {
+		const auto count = std::min(options.chunk_size, size - offset);
+		livekit::DataPacket chunk_packet;
+		PopulateStreamPacket(chunk_packet, options);
+		auto* chunk = chunk_packet.mutable_stream_chunk();
+		chunk->set_stream_id(stream_id);
+		chunk->set_chunk_index(chunk_index++);
+		chunk->set_content(data + offset, count);
+		if (!engine->SendDataPacket(chunk_packet, true)) {
+			return false;
+		}
+	}
+
+	livekit::DataPacket trailer_packet;
+	PopulateStreamPacket(trailer_packet, options);
+	trailer_packet.mutable_stream_trailer()->set_stream_id(stream_id);
+	return engine->SendDataPacket(trailer_packet, true);
+}
+
+} // namespace
+
 LocalParticipant::LocalParticipant(std::string sid, std::string identity,
                                    EncryptionType encryption_type, RtcEngine* engine,
                                    RoomOptions options)
@@ -281,8 +341,51 @@ bool LocalParticipant::PublishData(const std::vector<uint8_t>& data, DataPublish
 	return engine_->SendDataPacket(packet, options.reliable);
 }
 
+bool LocalParticipant::SendText(const std::string& text, TextSendOptions options) {
+	if (engine_ == nullptr || options.chunk_size == 0 ||
+	    options.chunk_size > kMaximumDataStreamChunkSize) {
+		return false;
+	}
+	const std::string stream_id = webrtc::CreateRandomUuid();
+	livekit::DataPacket header_packet;
+	PopulateStreamPacket(header_packet, options);
+	auto* header = header_packet.mutable_stream_header();
+	PopulateStreamHeader(*header, stream_id, text.size(), options);
+	header->set_mime_type("text/plain");
+	auto* text_header = header->mutable_text_header();
+	text_header->set_operation_type(livekit::DataStream_OperationType_CREATE);
+	text_header->set_reply_to_stream_id(options.reply_to_stream_id);
+	for (const auto& attached_stream_id : options.attached_stream_ids) {
+		text_header->add_attached_stream_ids(attached_stream_id);
+	}
+	if (!engine_->SendDataPacket(header_packet, true)) {
+		return false;
+	}
+	return SendStreamPayload(engine_, stream_id, reinterpret_cast<const uint8_t*>(text.data()),
+	                         text.size(), options);
+}
+
+bool LocalParticipant::SendBytes(const std::vector<uint8_t>& data, ByteSendOptions options) {
+	if (engine_ == nullptr || options.chunk_size == 0 ||
+	    options.chunk_size > kMaximumDataStreamChunkSize) {
+		return false;
+	}
+	const std::string stream_id = webrtc::CreateRandomUuid();
+	livekit::DataPacket header_packet;
+	PopulateStreamPacket(header_packet, options);
+	auto* header = header_packet.mutable_stream_header();
+	PopulateStreamHeader(*header, stream_id, data.size(), options);
+	header->set_mime_type(options.mime_type);
+	header->mutable_byte_header()->set_name(options.name);
+	if (!engine_->SendDataPacket(header_packet, true)) {
+		return false;
+	}
+	return SendStreamPayload(engine_, stream_id, data.data(), data.size(), options);
+}
+
 bool LocalParticipant::SendFile(const std::string& path, FileSendOptions options) {
-	if (engine_ == nullptr || options.chunk_size == 0 || options.chunk_size > 15'000) {
+	if (engine_ == nullptr || options.chunk_size == 0 ||
+	    options.chunk_size > kMaximumDataStreamChunkSize) {
 		return false;
 	}
 	std::ifstream input(path, std::ios::binary | std::ios::ate);
@@ -297,22 +400,12 @@ bool LocalParticipant::SendFile(const std::string& path, FileSendOptions options
 	input.seekg(0, std::ios::beg);
 
 	const std::string stream_id = webrtc::CreateRandomUuid();
-	auto add_destinations = [&options](livekit::DataPacket& packet) {
-		for (const auto& identity : options.destination_identities) {
-			packet.add_destination_identities(identity);
-		}
-	};
 
 	livekit::DataPacket header_packet;
-	add_destinations(header_packet);
+	PopulateStreamPacket(header_packet, options);
 	auto* header = header_packet.mutable_stream_header();
-	header->set_stream_id(stream_id);
-	header->set_timestamp(std::chrono::duration_cast<std::chrono::milliseconds>(
-	                          std::chrono::system_clock::now().time_since_epoch())
-	                          .count());
-	header->set_topic(options.topic);
+	PopulateStreamHeader(*header, stream_id, file_size, options);
 	header->set_mime_type(options.mime_type);
-	header->set_total_length(file_size);
 	header->mutable_byte_header()->set_name(std::filesystem::path(path).filename().string());
 	if (!engine_->SendDataPacket(header_packet, true)) {
 		return false;
@@ -327,7 +420,7 @@ bool LocalParticipant::SendFile(const std::string& path, FileSendOptions options
 			break;
 		}
 		livekit::DataPacket chunk_packet;
-		add_destinations(chunk_packet);
+		PopulateStreamPacket(chunk_packet, options);
 		auto* chunk = chunk_packet.mutable_stream_chunk();
 		chunk->set_stream_id(stream_id);
 		chunk->set_chunk_index(chunk_index++);
@@ -338,7 +431,7 @@ bool LocalParticipant::SendFile(const std::string& path, FileSendOptions options
 	}
 
 	livekit::DataPacket trailer_packet;
-	add_destinations(trailer_packet);
+	PopulateStreamPacket(trailer_packet, options);
 	trailer_packet.mutable_stream_trailer()->set_stream_id(stream_id);
 	return engine_->SendDataPacket(trailer_packet, true);
 }

--- a/src/core/participant/local_participant.h
+++ b/src/core/participant/local_participant.h
@@ -59,6 +59,8 @@ public:
 	bool SetName(const std::string& name) override;
 	bool SetAttributes(const std::map<std::string, std::string>& attributes) override;
 	bool PublishData(const std::vector<uint8_t>& data, DataPublishOptions options) override;
+	bool SendText(const std::string& text, TextSendOptions options) override;
+	bool SendBytes(const std::vector<uint8_t>& data, ByteSendOptions options) override;
 	bool SendFile(const std::string& path, FileSendOptions options) override;
 	void SetEventListener(RoomEventInterface* listener);
 

--- a/src/core/room.cpp
+++ b/src/core/room.cpp
@@ -29,6 +29,8 @@
 #include <tuple>
 
 namespace {
+constexpr uint64_t kMaximumBufferedDataStreamSize = 64ULL * 1024 * 1024;
+
 static livekit::core::EngineOptions make_engine_config(livekit::core::RoomOptions room_options) {
 	livekit::core::EngineOptions engine_options;
 
@@ -181,8 +183,9 @@ bool Room::Disconnect() {
 	detached_tracks.clear();
 	rtc_engine_->Disconnect();
 	{
-		std::lock_guard<std::mutex> guard(incoming_files_mutex_);
+		std::lock_guard<std::mutex> guard(incoming_streams_mutex_);
 		incoming_files_.clear();
+		incoming_texts_.clear();
 	}
 	state_ = RoomState::Disconnected;
 	if (auto* listener = event_listener_.load()) {
@@ -551,9 +554,54 @@ void Room::DataPacketEvent(const livekit::DataPacket& packet) {
 		}
 		return;
 	}
+	if (packet.has_stream_header() && packet.stream_header().has_text_header()) {
+		const auto& header = packet.stream_header();
+		if (header.stream_id().empty() ||
+		    header.compression() != livekit::DataStream_CompressionType_NONE) {
+			return;
+		}
+		IncomingText incoming;
+		incoming.event.stream_id = header.stream_id();
+		incoming.event.topic = header.topic();
+		incoming.event.participant_identity = packet.participant_identity();
+		incoming.event.reply_to_stream_id = header.text_header().reply_to_stream_id();
+		incoming.event.attached_stream_ids.assign(
+		    header.text_header().attached_stream_ids().begin(),
+		    header.text_header().attached_stream_ids().end());
+		incoming.event.attributes.insert(header.attributes().begin(), header.attributes().end());
+		incoming.event.timestamp = header.timestamp();
+		if (header.has_total_length()) {
+			incoming.expected_length = header.total_length();
+			if (*incoming.expected_length > std::numeric_limits<std::size_t>::max() ||
+			    *incoming.expected_length > kMaximumBufferedDataStreamSize) {
+				return;
+			}
+			try {
+				incoming.event.text.reserve(static_cast<std::size_t>(*incoming.expected_length));
+			} catch (const std::exception&) {
+				return;
+			}
+		}
+		if (header.has_inline_content()) {
+			if (incoming.expected_length &&
+			    header.inline_content().size() != *incoming.expected_length) {
+				return;
+			}
+			incoming.event.text = header.inline_content();
+			if (auto* listener = event_listener_.load()) {
+				listener->OnTextReceived(incoming.event);
+			}
+			return;
+		}
+		std::lock_guard<std::mutex> guard(incoming_streams_mutex_);
+		incoming_files_.erase(header.stream_id());
+		incoming_texts_[header.stream_id()] = std::move(incoming);
+		return;
+	}
 	if (packet.has_stream_header() && packet.stream_header().has_byte_header()) {
 		const auto& header = packet.stream_header();
-		if (header.stream_id().empty()) {
+		if (header.stream_id().empty() ||
+		    header.compression() != livekit::DataStream_CompressionType_NONE) {
 			return;
 		}
 		IncomingFile incoming;
@@ -562,32 +610,76 @@ void Room::DataPacketEvent(const livekit::DataPacket& packet) {
 		incoming.event.mime_type = header.mime_type();
 		incoming.event.topic = header.topic();
 		incoming.event.participant_identity = packet.participant_identity();
-		incoming.expected_length = header.has_total_length() ? header.total_length() : 0;
-		if (incoming.expected_length > 0) {
-			if (incoming.expected_length > std::numeric_limits<std::size_t>::max()) {
+		incoming.event.attributes.insert(header.attributes().begin(), header.attributes().end());
+		incoming.event.timestamp = header.timestamp();
+		if (header.has_total_length()) {
+			incoming.expected_length = header.total_length();
+			if (*incoming.expected_length > std::numeric_limits<std::size_t>::max() ||
+			    *incoming.expected_length > kMaximumBufferedDataStreamSize) {
 				return;
 			}
 			try {
-				incoming.event.data.reserve(static_cast<std::size_t>(incoming.expected_length));
+				incoming.event.data.reserve(static_cast<std::size_t>(*incoming.expected_length));
 			} catch (const std::exception&) {
 				return;
 			}
 		}
-		std::lock_guard<std::mutex> guard(incoming_files_mutex_);
+		if (header.has_inline_content()) {
+			if (incoming.expected_length &&
+			    header.inline_content().size() != *incoming.expected_length) {
+				return;
+			}
+			incoming.event.data.assign(header.inline_content().begin(),
+			                           header.inline_content().end());
+			if (auto* listener = event_listener_.load()) {
+				ByteReceivedEvent byte_event;
+				static_cast<FileReceivedEvent&>(byte_event) = incoming.event;
+				listener->OnByteReceived(byte_event);
+				if (!incoming.event.name.empty()) {
+					listener->OnFileReceived(incoming.event);
+				}
+			}
+			return;
+		}
+		std::lock_guard<std::mutex> guard(incoming_streams_mutex_);
+		incoming_texts_.erase(header.stream_id());
 		incoming_files_[header.stream_id()] = std::move(incoming);
 		return;
 	}
 	if (packet.has_stream_chunk()) {
 		const auto& chunk = packet.stream_chunk();
-		std::lock_guard<std::mutex> guard(incoming_files_mutex_);
+		std::lock_guard<std::mutex> guard(incoming_streams_mutex_);
+		auto text = incoming_texts_.find(chunk.stream_id());
+		if (text != incoming_texts_.end()) {
+			if (chunk.chunk_index() != text->second.next_chunk) {
+				incoming_texts_.erase(text);
+				return;
+			}
+			const auto content_size = static_cast<uint64_t>(chunk.content().size());
+			if (content_size > kMaximumBufferedDataStreamSize - text->second.event.text.size() ||
+			    (text->second.expected_length &&
+			     (text->second.event.text.size() > *text->second.expected_length ||
+			      content_size > *text->second.expected_length - text->second.event.text.size()))) {
+				incoming_texts_.erase(text);
+				return;
+			}
+			text->second.event.text.append(chunk.content());
+			++text->second.next_chunk;
+			return;
+		}
 		auto it = incoming_files_.find(chunk.stream_id());
-		if (it == incoming_files_.end() || chunk.chunk_index() != it->second.next_chunk) {
+		if (it == incoming_files_.end()) {
+			return;
+		}
+		if (chunk.chunk_index() != it->second.next_chunk) {
+			incoming_files_.erase(it);
 			return;
 		}
 		const auto content_size = static_cast<uint64_t>(chunk.content().size());
-		if (it->second.expected_length != 0 &&
-		    (it->second.event.data.size() > it->second.expected_length ||
-		     content_size > it->second.expected_length - it->second.event.data.size())) {
+		if (content_size > kMaximumBufferedDataStreamSize - it->second.event.data.size() ||
+		    (it->second.expected_length &&
+		     (it->second.event.data.size() > *it->second.expected_length ||
+		      content_size > *it->second.expected_length - it->second.event.data.size()))) {
 			incoming_files_.erase(it);
 			return;
 		}
@@ -597,20 +689,51 @@ void Room::DataPacketEvent(const livekit::DataPacket& packet) {
 		return;
 	}
 	if (packet.has_stream_trailer()) {
+		TextReceivedEvent text_event;
+		bool has_text_event = false;
 		FileReceivedEvent event;
+		bool has_byte_event = false;
 		{
-			std::lock_guard<std::mutex> guard(incoming_files_mutex_);
-			auto it = incoming_files_.find(packet.stream_trailer().stream_id());
-			if (it == incoming_files_.end() || !packet.stream_trailer().reason().empty() ||
-			    (it->second.expected_length != 0 &&
-			     it->second.event.data.size() != it->second.expected_length)) {
-				return;
+			std::lock_guard<std::mutex> guard(incoming_streams_mutex_);
+			auto text = incoming_texts_.find(packet.stream_trailer().stream_id());
+			if (text != incoming_texts_.end()) {
+				if (packet.stream_trailer().reason().empty() &&
+				    (!text->second.expected_length ||
+				     text->second.event.text.size() == *text->second.expected_length)) {
+					for (const auto& [key, value] : packet.stream_trailer().attributes()) {
+						text->second.event.attributes[key] = value;
+					}
+					text_event = std::move(text->second.event);
+					has_text_event = true;
+				}
+				incoming_texts_.erase(text);
 			}
-			event = std::move(it->second.event);
-			incoming_files_.erase(it);
+			auto it = incoming_files_.find(packet.stream_trailer().stream_id());
+			if (it != incoming_files_.end()) {
+				if (packet.stream_trailer().reason().empty() &&
+				    (!it->second.expected_length ||
+				     it->second.event.data.size() == *it->second.expected_length)) {
+					for (const auto& [key, value] : packet.stream_trailer().attributes()) {
+						it->second.event.attributes[key] = value;
+					}
+					event = std::move(it->second.event);
+					has_byte_event = true;
+				}
+				incoming_files_.erase(it);
+			}
 		}
 		if (auto* listener = event_listener_.load()) {
-			listener->OnFileReceived(event);
+			if (has_text_event) {
+				listener->OnTextReceived(text_event);
+			}
+			if (has_byte_event) {
+				ByteReceivedEvent byte_event;
+				static_cast<FileReceivedEvent&>(byte_event) = event;
+				listener->OnByteReceived(byte_event);
+				if (!event.name.empty()) {
+					listener->OnFileReceived(event);
+				}
+			}
 		}
 	}
 }

--- a/src/core/room.h
+++ b/src/core/room.h
@@ -30,6 +30,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 
 namespace livekit {
 namespace core {
@@ -88,7 +89,12 @@ private:
 
 	struct IncomingFile {
 		FileReceivedEvent event;
-		uint64_t expected_length = 0;
+		std::optional<uint64_t> expected_length;
+		uint64_t next_chunk = 0;
+	};
+	struct IncomingText {
+		TextReceivedEvent event;
+		std::optional<uint64_t> expected_length;
 		uint64_t next_chunk = 0;
 	};
 
@@ -101,8 +107,9 @@ private:
 	std::map<std::string, std::shared_ptr<RemoteTrack>> remote_tracks_;
 	std::map<std::string, webrtc::scoped_refptr<webrtc::MediaStreamTrackInterface>>
 	    pending_media_tracks_;
-	std::mutex incoming_files_mutex_;
+	std::mutex incoming_streams_mutex_;
 	std::map<std::string, IncomingFile> incoming_files_;
+	std::map<std::string, IncomingText> incoming_texts_;
 	ServerInfo server_info_;
 	mutable std::mutex room_info_mutex_;
 	livekit::Room room_info_;

--- a/test/functional/c_api_test.cpp
+++ b/test/functional/c_api_test.cpp
@@ -39,6 +39,17 @@ TEST(CApiTest, ExposesVersionAndOptionDefaults) {
 	EXPECT_STREQ(file.topic, "files");
 	EXPECT_STREQ(file.mime_type, "application/octet-stream");
 	EXPECT_EQ(file.chunk_size, 15000u);
+
+	lk_text_send_options_t text;
+	lk_text_send_options_init(&text);
+	EXPECT_EQ(text.struct_size, sizeof(text));
+	EXPECT_EQ(text.chunk_size, 15000u);
+
+	lk_byte_send_options_t bytes;
+	lk_byte_send_options_init(&bytes);
+	EXPECT_EQ(bytes.struct_size, sizeof(bytes));
+	EXPECT_STREQ(bytes.mime_type, "application/octet-stream");
+	EXPECT_EQ(bytes.chunk_size, 15000u);
 }
 
 TEST(CApiTest, ValidatesArgumentsWithoutThrowingAcrossAbi) {
@@ -50,6 +61,8 @@ TEST(CApiTest, ValidatesArgumentsWithoutThrowingAcrossAbi) {
 	          LK_STATUS_INVALID_ARGUMENT);
 	EXPECT_EQ(lk_local_track_unpublish(nullptr, 1), LK_STATUS_INVALID_ARGUMENT);
 	EXPECT_EQ(lk_room_republish_all_tracks(nullptr), LK_STATUS_INVALID_ARGUMENT);
+	EXPECT_EQ(lk_room_send_text(nullptr, nullptr, nullptr), LK_STATUS_INVALID_ARGUMENT);
+	EXPECT_EQ(lk_room_send_bytes(nullptr, nullptr, 0, nullptr), LK_STATUS_INVALID_ARGUMENT);
 }
 
 TEST(CApiTest, CreatesRoomAndCapturesLocalFrames) {
@@ -66,6 +79,8 @@ TEST(CApiTest, CreatesRoomAndCapturesLocalFrames) {
 	lk_room_callbacks_init(&callbacks);
 	EXPECT_EQ(callbacks.on_local_track_published, nullptr);
 	EXPECT_EQ(callbacks.on_local_track_unpublished, nullptr);
+	EXPECT_EQ(callbacks.on_text_received, nullptr);
+	EXPECT_EQ(callbacks.on_byte_received, nullptr);
 	EXPECT_EQ(lk_room_set_callbacks(room, &callbacks), LK_STATUS_OK);
 	EXPECT_EQ(lk_room_set_callbacks(room, nullptr), LK_STATUS_OK);
 	EXPECT_EQ(lk_room_set_remote_track_subscribed(room, "missing", "missing", 1),

--- a/test/functional/participant_state_test.cpp
+++ b/test/functional/participant_state_test.cpp
@@ -144,6 +144,113 @@ public:
 	bool participant_is_local = false;
 };
 
+class DataStreamEvents final : public RoomEventInterface {
+public:
+	void OnConnected() override {}
+	void OnTextReceived(const TextReceivedEvent& event) override { texts.push_back(event); }
+	void OnByteReceived(const ByteReceivedEvent& event) override { bytes.push_back(event); }
+	void OnFileReceived(const FileReceivedEvent& event) override { files.push_back(event); }
+
+	std::vector<TextReceivedEvent> texts;
+	std::vector<ByteReceivedEvent> bytes;
+	std::vector<FileReceivedEvent> files;
+};
+
+livekit::DataPacket StreamHeader(const std::string& id, uint64_t size) {
+	livekit::DataPacket packet;
+	packet.set_participant_identity("sender");
+	auto* header = packet.mutable_stream_header();
+	header->set_stream_id(id);
+	header->set_topic("stream-topic");
+	header->set_timestamp(1234);
+	header->set_total_length(size);
+	(*header->mutable_attributes())["kind"] = "test";
+	return packet;
+}
+
+livekit::DataPacket StreamChunk(const std::string& id, uint64_t index, const std::string& content) {
+	livekit::DataPacket packet;
+	auto* chunk = packet.mutable_stream_chunk();
+	chunk->set_stream_id(id);
+	chunk->set_chunk_index(index);
+	chunk->set_content(content);
+	return packet;
+}
+
+livekit::DataPacket StreamTrailer(const std::string& id) {
+	livekit::DataPacket packet;
+	packet.mutable_stream_trailer()->set_stream_id(id);
+	return packet;
+}
+
+TEST(DataStreamStateTest, ReassemblesTextAndByteStreams) {
+	Room room;
+	DataStreamEvents events;
+	room.AddEventListener(&events);
+
+	auto text_header = StreamHeader("text-1", 11);
+	auto* text = text_header.mutable_stream_header()->mutable_text_header();
+	text->set_reply_to_stream_id("parent");
+	text->add_attached_stream_ids("file-1");
+	room.DataPacketEvent(text_header);
+	room.DataPacketEvent(StreamChunk("text-1", 0, "hello "));
+	room.DataPacketEvent(StreamChunk("text-1", 1, "world"));
+	room.DataPacketEvent(StreamTrailer("text-1"));
+	ASSERT_EQ(events.texts.size(), 1u);
+	EXPECT_EQ(events.texts[0].text, "hello world");
+	EXPECT_EQ(events.texts[0].reply_to_stream_id, "parent");
+	EXPECT_EQ(events.texts[0].attached_stream_ids, std::vector<std::string>{"file-1"});
+	EXPECT_EQ(events.texts[0].attributes.at("kind"), "test");
+	EXPECT_EQ(events.texts[0].participant_identity, "sender");
+	EXPECT_EQ(events.texts[0].timestamp, 1234);
+
+	auto bytes_header = StreamHeader("bytes-1", 4);
+	bytes_header.mutable_stream_header()->set_mime_type("application/test");
+	bytes_header.mutable_stream_header()->mutable_byte_header();
+	room.DataPacketEvent(bytes_header);
+	room.DataPacketEvent(StreamChunk("bytes-1", 0, "data"));
+	room.DataPacketEvent(StreamTrailer("bytes-1"));
+	ASSERT_EQ(events.bytes.size(), 1u);
+	EXPECT_EQ(events.bytes[0].data, std::vector<uint8_t>({'d', 'a', 't', 'a'}));
+	EXPECT_TRUE(events.files.empty());
+
+	auto file_header = StreamHeader("file-1", 4);
+	file_header.mutable_stream_header()->mutable_byte_header()->set_name("test.bin");
+	room.DataPacketEvent(file_header);
+	room.DataPacketEvent(StreamChunk("file-1", 0, "file"));
+	auto file_trailer = StreamTrailer("file-1");
+	(*file_trailer.mutable_stream_trailer()->mutable_attributes())["complete"] = "true";
+	room.DataPacketEvent(file_trailer);
+	ASSERT_EQ(events.bytes.size(), 2u);
+	ASSERT_EQ(events.files.size(), 1u);
+	EXPECT_EQ(events.files[0].name, "test.bin");
+	EXPECT_EQ(events.files[0].attributes.at("complete"), "true");
+	EXPECT_EQ(events.files[0].timestamp, 1234);
+	room.RemoveEventListener();
+}
+
+TEST(DataStreamStateTest, HandlesInlineStreamsAndRejectsInvalidChunks) {
+	Room room;
+	DataStreamEvents events;
+	room.AddEventListener(&events);
+
+	auto inline_text = StreamHeader("inline", 5);
+	inline_text.mutable_stream_header()->mutable_text_header();
+	inline_text.mutable_stream_header()->set_inline_content("hello");
+	room.DataPacketEvent(inline_text);
+	ASSERT_EQ(events.texts.size(), 1u);
+	EXPECT_EQ(events.texts[0].text, "hello");
+
+	auto invalid = StreamHeader("invalid", 3);
+	invalid.mutable_stream_header()->mutable_byte_header()->set_name("bad.bin");
+	room.DataPacketEvent(invalid);
+	room.DataPacketEvent(StreamChunk("invalid", 1, "bad"));
+	room.DataPacketEvent(StreamTrailer("invalid"));
+	EXPECT_TRUE(events.bytes.empty());
+	EXPECT_TRUE(events.files.empty());
+	room.RemoveEventListener();
+}
+
 TEST(LocalTrackStateTest, HandlesServerInitiatedUnpublishOnce) {
 	Room room;
 	LocalTrackEvents events;

--- a/test/integration/livekit_server_test.cpp
+++ b/test/integration/livekit_server_test.cpp
@@ -115,6 +115,18 @@ public:
 		file_data_ = event.data;
 	}
 
+	void OnTextReceived(const TextReceivedEvent& event) override {
+		std::lock_guard<std::mutex> guard(lock_);
+		text_topic_ = event.topic;
+		text_ = event.text;
+	}
+
+	void OnByteReceived(const ByteReceivedEvent& event) override {
+		std::lock_guard<std::mutex> guard(lock_);
+		byte_topic_ = event.topic;
+		byte_data_ = event.data;
+	}
+
 	bool audio_received() const { return audio_subscribed_.load() && audio_frames_.load() >= 5; }
 	bool video_received() const { return video_subscribed_.load() && video_frames_.load() >= 3; }
 	bool video_subscribed() const { return video_subscribed_.load(); }
@@ -134,6 +146,14 @@ public:
 		return file_name_ == name && file_mime_type_ == mime_type && file_topic_ == topic &&
 		       file_data_ == expected;
 	}
+	bool received_text(const std::string& topic, const std::string& text) {
+		std::lock_guard<std::mutex> guard(lock_);
+		return text_topic_ == topic && text_ == text;
+	}
+	bool received_bytes(const std::string& topic, const std::vector<uint8_t>& data) {
+		std::lock_guard<std::mutex> guard(lock_);
+		return byte_topic_ == topic && byte_data_ == data;
+	}
 
 private:
 	std::atomic<bool> audio_subscribed_{false};
@@ -152,6 +172,10 @@ private:
 	std::string file_mime_type_;
 	std::string file_topic_;
 	std::vector<uint8_t> file_data_;
+	std::string text_topic_;
+	std::string text_;
+	std::string byte_topic_;
+	std::vector<uint8_t> byte_data_;
 };
 
 class ParticipantEvents final : public RoomEventInterface {
@@ -498,6 +522,21 @@ TEST(LiveKitServerTest, TransfersDataAndFileWithoutMediaTracks) {
 	ASSERT_TRUE(sender->GetLocalParticipant()->PublishData(lossy_payload, data_options));
 	ASSERT_TRUE(
 	    WaitUntil([&] { return events.received_data("integration-lossy", lossy_payload, false); }));
+
+	TextSendOptions text_options;
+	text_options.topic = "integration-text";
+	text_options.destination_identities = {receiver->GetLocalParticipant()->Identity()};
+	ASSERT_TRUE(sender->GetLocalParticipant()->SendText("hello from C++", text_options));
+	ASSERT_TRUE(
+	    WaitUntil([&] { return events.received_text("integration-text", "hello from C++"); }));
+
+	const std::vector<uint8_t> byte_payload{'b', 'y', 't', 'e', 's'};
+	ByteSendOptions byte_options;
+	byte_options.topic = "integration-bytes";
+	byte_options.destination_identities = {receiver->GetLocalParticipant()->Identity()};
+	ASSERT_TRUE(sender->GetLocalParticipant()->SendBytes(byte_payload, byte_options));
+	ASSERT_TRUE(
+	    WaitUntil([&] { return events.received_bytes("integration-bytes", byte_payload); }));
 
 	std::vector<uint8_t> file_payload(40 * 1024);
 	for (std::size_t i = 0; i < file_payload.size(); ++i) {


### PR DESCRIPTION
Add C++ and C APIs for sending and receiving LiveKit text and byte streams, including metadata, chunk validation, examples, and test coverage.

Validated with the VS2022 Release build and 35 unit/functional tests. Integration targets build successfully; live server execution requires an available service.