### PR TITLE
feat: resume interrupted room sessions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,8 @@ Because webrtc requires C++20.
 ## Features
 
 - [x] WebSocket signaling and room lifecycle
-- [x] Automatic full reconnect with local track republishing
+- [x] Protocol-level signal resume with SyncState/ICE restart and automatic full-reconnect fallback
+- [x] Structured LiveKit disconnect reasons in C++ and C APIs
 - [x] Room and participant state, track publications, active speakers, and quality events
 - [x] Participant metadata, display name, and attribute updates
 - [x] Connection state, identity lookup, local track mute, and remote subscription controls

--- a/examples/README.md
+++ b/examples/README.md
@@ -72,8 +72,11 @@ Connects to a room, prints the local participant identity and SID, and disconnec
 ### `room_event`
 
 Receives room events, subscribed tracks, decoded PCM/I420 frames, data messages, and completed
-files. It also reports `OnReconnecting` and `OnReconnected` while the SDK restores an interrupted
-session. The optional third argument controls how many seconds to listen and defaults to 30.
+files. It also reports `OnReconnecting` and `OnReconnected` while the SDK first attempts a
+protocol-level signal resume and falls back to a full reconnect when required, and prints the
+protocol-level reason when the room disconnects. Applications can query the same value later with
+`RoomInterface::LastDisconnectReason()`. The optional third argument controls how many seconds to
+listen and defaults to 30.
 
 ```powershell
 & "out/build/vs2022-x64-release/examples/room_event/Release/room_event.exe" `

--- a/examples/c_sample/sample.c
+++ b/examples/c_sample/sample.c
@@ -35,6 +35,12 @@ static void on_reconnected(void* user_data, lk_room_t* room) {
 	puts("Reconnected event received");
 }
 
+static void on_disconnected(void* user_data, lk_room_t* room, lk_disconnect_reason_t reason) {
+	(void)user_data;
+	(void)room;
+	printf("Disconnected event received, reason=%d\n", (int)reason);
+}
+
 static void on_participant_connected(void* user_data, lk_room_t* room,
                                      const lk_participant_info_t* participant) {
 	(void)user_data;
@@ -89,6 +95,7 @@ int main(int argc, char** argv) {
 	callbacks.on_connected = on_connected;
 	callbacks.on_reconnecting = on_reconnecting;
 	callbacks.on_reconnected = on_reconnected;
+	callbacks.on_disconnected_with_reason = on_disconnected;
 	callbacks.on_participant_connected = on_participant_connected;
 	callbacks.on_track_published = on_track_published;
 	lk_room_set_callbacks(room, &callbacks);

--- a/examples/room_event/room_event.cpp
+++ b/examples/room_event/room_event.cpp
@@ -17,7 +17,9 @@ public:
 		std::cout << "Room connected" << std::endl;
 	}
 
-	void OnDisconnected() override { std::cout << "Room disconnected" << std::endl; }
+	void OnDisconnected(livekit::core::DisconnectReason reason) override {
+		std::cout << "Room disconnected, reason=" << static_cast<int>(reason) << std::endl;
+	}
 	void OnReconnecting() override { std::cout << "Room reconnecting" << std::endl; }
 	void OnReconnected() override { std::cout << "Room reconnected" << std::endl; }
 

--- a/include/livekit/capi/livekit.h
+++ b/include/livekit/capi/livekit.h
@@ -55,6 +55,26 @@ typedef enum lk_room_state {
 	LK_ROOM_STATE_RECONNECTING = 5
 } lk_room_state_t;
 
+typedef enum lk_disconnect_reason {
+	LK_DISCONNECT_REASON_UNKNOWN = 0,
+	LK_DISCONNECT_REASON_CLIENT_INITIATED = 1,
+	LK_DISCONNECT_REASON_DUPLICATE_IDENTITY = 2,
+	LK_DISCONNECT_REASON_SERVER_SHUTDOWN = 3,
+	LK_DISCONNECT_REASON_PARTICIPANT_REMOVED = 4,
+	LK_DISCONNECT_REASON_ROOM_DELETED = 5,
+	LK_DISCONNECT_REASON_STATE_MISMATCH = 6,
+	LK_DISCONNECT_REASON_JOIN_FAILURE = 7,
+	LK_DISCONNECT_REASON_MIGRATION = 8,
+	LK_DISCONNECT_REASON_SIGNAL_CLOSE = 9,
+	LK_DISCONNECT_REASON_ROOM_CLOSED = 10,
+	LK_DISCONNECT_REASON_USER_UNAVAILABLE = 11,
+	LK_DISCONNECT_REASON_USER_REJECTED = 12,
+	LK_DISCONNECT_REASON_SIP_TRUNK_FAILURE = 13,
+	LK_DISCONNECT_REASON_CONNECTION_TIMEOUT = 14,
+	LK_DISCONNECT_REASON_MEDIA_FAILURE = 15,
+	LK_DISCONNECT_REASON_AGENT_ERROR = 16
+} lk_disconnect_reason_t;
+
 typedef enum lk_track_kind {
 	LK_TRACK_KIND_UNKNOWN = 0,
 	LK_TRACK_KIND_AUDIO = 1,
@@ -149,6 +169,8 @@ typedef struct lk_attribute {
 } lk_attribute_t;
 
 typedef void (*lk_room_event_callback)(void* user_data, lk_room_t* room);
+typedef void (*lk_room_disconnected_callback)(void* user_data, lk_room_t* room,
+                                              lk_disconnect_reason_t reason);
 typedef void (*lk_participant_event_callback)(void* user_data, lk_room_t* room,
                                               const lk_participant_info_t* participant);
 typedef void (*lk_track_event_callback)(void* user_data, lk_room_t* room,
@@ -201,6 +223,7 @@ typedef struct lk_room_callbacks {
 	lk_file_received_callback on_byte_received;
 	lk_room_event_callback on_reconnecting;
 	lk_room_event_callback on_reconnected;
+	lk_room_disconnected_callback on_disconnected_with_reason;
 } lk_room_callbacks_t;
 
 typedef struct lk_audio_source_options {
@@ -291,6 +314,7 @@ LKC_API lk_status_t lk_room_set_callbacks(lk_room_t* room, const lk_room_callbac
 LKC_API lk_status_t lk_room_connect(lk_room_t* room, const char* url, const char* token);
 LKC_API lk_status_t lk_room_disconnect(lk_room_t* room);
 LKC_API lk_room_state_t lk_room_state(const lk_room_t* room);
+LKC_API lk_disconnect_reason_t lk_room_disconnect_reason(const lk_room_t* room);
 LKC_API int lk_room_is_connected(const lk_room_t* room);
 LKC_API size_t lk_room_sid(const lk_room_t* room, char* buffer, size_t buffer_size);
 LKC_API size_t lk_room_name(const lk_room_t* room, char* buffer, size_t buffer_size);

--- a/include/livekit/core/option/signal_option.h
+++ b/include/livekit/core/option/signal_option.h
@@ -35,6 +35,7 @@ struct SignalOptions {
 	bool adaptive_stream = false;
 	bool reconnect = false;
 	int reconnect_reason = 0;
+	std::string participant_sid;
 	SignalSdkOptions sdk_options;
 };
 

--- a/include/livekit/core/room_event_interface.h
+++ b/include/livekit/core/room_event_interface.h
@@ -37,6 +37,28 @@ class RemoteTrackInterface;
 class ParticipantInterface;
 class TrackPublicationInterface;
 
+// Values intentionally match livekit.protocol.DisconnectReason so applications can preserve the
+// full server-provided reason without depending on generated protobuf headers.
+enum class DisconnectReason : int {
+	Unknown = 0,
+	ClientInitiated = 1,
+	DuplicateIdentity = 2,
+	ServerShutdown = 3,
+	ParticipantRemoved = 4,
+	RoomDeleted = 5,
+	StateMismatch = 6,
+	JoinFailure = 7,
+	Migration = 8,
+	SignalClose = 9,
+	RoomClosed = 10,
+	UserUnavailable = 11,
+	UserRejected = 12,
+	SipTrunkFailure = 13,
+	ConnectionTimeout = 14,
+	MediaFailure = 15,
+	AgentError = 16,
+};
+
 class RoomEventInterface {
 public:
 	virtual ~RoomEventInterface() {}
@@ -45,6 +67,8 @@ public:
 	virtual void OnReconnecting() {}
 	virtual void OnReconnected() {}
 	virtual void OnDisconnected() {}
+	// The default forwards to the legacy no-argument callback, preserving existing listeners.
+	virtual void OnDisconnected(DisconnectReason) { OnDisconnected(); }
 	virtual void OnParticipantConnected(RemoteParticipantInterface*) {}
 	virtual void OnParticipantDisconnected(RemoteParticipantInterface*) {}
 	virtual void OnTrackPublished(TrackPublicationInterface*, RemoteParticipantInterface*) {}

--- a/include/livekit/core/room_interface.h
+++ b/include/livekit/core/room_interface.h
@@ -54,6 +54,7 @@ public:
 	// Returns the full connection lifecycle state. Unlike IsConnected(), this distinguishes
 	// connecting, disconnecting, and failed rooms.
 	RoomState State() const;
+	DisconnectReason LastDisconnectReason() const;
 	virtual bool IsConnected() = 0;
 	virtual bool Disconnect() = 0;
 	virtual std::string Sid() { return {}; }

--- a/src/capi/livekit.cpp
+++ b/src/capi/livekit.cpp
@@ -185,6 +185,10 @@ lk_room_state_t ToCRoomState(core::RoomInterface::RoomState state) {
 	}
 }
 
+lk_disconnect_reason_t ToCDisconnectReason(core::DisconnectReason reason) {
+	return static_cast<lk_disconnect_reason_t>(reason);
+}
+
 struct OwnedParticipantInfo {
 	explicit OwnedParticipantInfo(core::ParticipantInterface* participant) {
 		if (participant == nullptr) {
@@ -341,11 +345,17 @@ public:
 		});
 	}
 
-	void OnDisconnected() override {
+	void OnDisconnected() override { OnDisconnected(core::DisconnectReason::Unknown); }
+
+	void OnDisconnected(core::DisconnectReason reason) override {
 		owner_->state->connected.store(false);
-		InvokeRoomCallback(owner_, [this](const lk_room_callbacks_t& callbacks) {
+		InvokeRoomCallback(owner_, [this, reason](const lk_room_callbacks_t& callbacks) {
 			if (callbacks.on_disconnected != nullptr) {
 				callbacks.on_disconnected(callbacks.user_data, owner_);
+			}
+			if (callbacks.on_disconnected_with_reason != nullptr) {
+				callbacks.on_disconnected_with_reason(callbacks.user_data, owner_,
+				                                      ToCDisconnectReason(reason));
 			}
 		});
 	}
@@ -775,6 +785,13 @@ lk_room_state_t lk_room_state(const lk_room_t* room) {
 		return LK_ROOM_STATE_DISCONNECTED;
 	}
 	return ToCRoomState(room->room->State());
+}
+
+lk_disconnect_reason_t lk_room_disconnect_reason(const lk_room_t* room) {
+	if (room == nullptr || room->room == nullptr) {
+		return LK_DISCONNECT_REASON_UNKNOWN;
+	}
+	return ToCDisconnectReason(room->room->LastDisconnectReason());
 }
 
 int lk_room_is_connected(const lk_room_t* room) {

--- a/src/core/detail/peer_transport.cpp
+++ b/src/core/detail/peer_transport.cpp
@@ -392,6 +392,20 @@ const webrtc::PeerConnectionInterface::PeerConnectionState PeerTransport::GetCon
 	return webrtc::PeerConnectionInterface::PeerConnectionState::kClosed;
 }
 
+bool PeerTransport::SetConfiguration(
+    const webrtc::PeerConnectionInterface::RTCConfiguration& config) {
+	std::lock_guard<std::mutex> guard(pc_lock_);
+	if (!pc_) {
+		return false;
+	}
+	const auto result = pc_->SetConfiguration(config);
+	if (!result.ok()) {
+		return false;
+	}
+	rtc_config_ = config;
+	return true;
+}
+
 std::vector<webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>>
 PeerTransport::GetTransceivers() const {
 	std::lock_guard<std::mutex> guard(pc_lock_);
@@ -502,7 +516,7 @@ void PeerTransport::AddIceCandidate(const std::string& candidate_json_str) {
 	return;
 }
 
-bool PeerTransport::Negotiate() {
+bool PeerTransport::Negotiate(bool ice_restart) {
 	// May throw.
 	webrtc::PeerConnectionInterface::RTCOfferAnswerOptions options;
 	options.offer_to_receive_video = 0;
@@ -510,6 +524,7 @@ bool PeerTransport::Negotiate() {
 	options.voice_activity_detection = true;
 	options.use_rtp_mux = true;
 	options.use_obsolete_sctp_sdp = true;
+	options.ice_restart = ice_restart;
 
 	try {
 		createAndSendPublisherOffer(options);

--- a/src/core/detail/peer_transport.h
+++ b/src/core/detail/peer_transport.h
@@ -186,6 +186,7 @@ public:
 	const std::string GetPendingLocalDescription();
 	const std::string GetPendingRemoteDescription();
 	const webrtc::PeerConnectionInterface::PeerConnectionState GetConnectionState();
+	bool SetConfiguration(const webrtc::PeerConnectionInterface::RTCConfiguration& config);
 
 	std::vector<webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>> GetTransceivers() const;
 	webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>
@@ -200,7 +201,7 @@ public:
 
 	void AddIceCandidate(const std::string& candidate_json_str);
 
-	bool Negotiate();
+	bool Negotiate(bool ice_restart = false);
 
 	bool TestFlushIceCandidate();
 

--- a/src/core/detail/rtc_engine.cpp
+++ b/src/core/detail/rtc_engine.cpp
@@ -29,6 +29,16 @@ namespace {
 constexpr auto kAddTrackTimeout = std::chrono::seconds(10);
 constexpr auto kDataChannelOpenTimeout = std::chrono::seconds(10);
 constexpr auto kRecoveryRtcTimeout = std::chrono::seconds(15);
+
+livekit::ReconnectReason ToReconnectReason(livekit::DisconnectReason reason) {
+	if (reason == livekit::DisconnectReason::MEDIA_FAILURE) {
+		return livekit::ReconnectReason::RR_PUBLISHER_FAILED;
+	}
+	if (reason == livekit::DisconnectReason::SIGNAL_CLOSE) {
+		return livekit::ReconnectReason::RR_SIGNAL_DISCONNECTED;
+	}
+	return livekit::ReconnectReason::RR_UNKNOWN;
+}
 } // namespace
 
 namespace livekit {
@@ -56,6 +66,8 @@ livekit::JoinResponse RtcEngine::Connect(std::string url, std::string token,
 	}
 	recovery_stop_ = false;
 	recovering_connection_ = false;
+	force_full_reconnect_ = false;
+	recovery_failure_reason_ = livekit::DisconnectReason::UNKNOWN_REASON;
 	{
 		std::lock_guard<std::mutex> guard(rtc_connected_mutex_);
 		rtc_connected_ = false;
@@ -106,6 +118,103 @@ livekit::JoinResponse RtcEngine::ConnectTransport(const std::string& url, const 
 	}
 
 	return response;
+}
+
+bool RtcEngine::ResumeTransport(const std::string& url, const std::string& token,
+                                const EngineOptions& options, livekit::DisconnectReason reason) {
+	SignalOptions signal_options = options.signal_options;
+	int ping_timeout = 0;
+	int ping_interval = 0;
+	{
+		std::lock_guard<std::mutex> guard(session_lock_);
+		if (!rtc_session_ || !join_resp_.has_participant()) {
+			return false;
+		}
+		signal_options.participant_sid = join_resp_.participant().sid();
+		ping_timeout = join_resp_.ping_timeout();
+		ping_interval = join_resp_.ping_interval();
+	}
+	signal_options.reconnect = true;
+	signal_options.reconnect_reason = static_cast<int>(ToReconnectReason(reason));
+
+	auto created = SignalClient::Create(url, token, signal_options);
+	if (!created) {
+		return false;
+	}
+	auto resumed_signal = std::shared_ptr<SignalClient>(std::move(created));
+	resumed_signal->SetPingConfig(ping_timeout, ping_interval);
+	resumed_signal->AddObserver(this);
+
+	std::shared_ptr<SignalClient> previous_signal;
+	{
+		std::lock_guard<std::mutex> guard(signal_client_lock_);
+		previous_signal.swap(signal_client_);
+		signal_client_ = resumed_signal;
+	}
+	if (previous_signal) {
+		previous_signal->RemoveObserver();
+		previous_signal->Close();
+	}
+
+	if (!resumed_signal->Resume() || recovery_stop_ || force_full_reconnect_) {
+		return false;
+	}
+	const auto reconnect_response = resumed_signal->ReconnectResponseSnapshot();
+	{
+		std::lock_guard<std::mutex> guard(session_lock_);
+		if (!rtc_session_ || !rtc_session_->UpdateConfiguration(reconnect_response)) {
+			return false;
+		}
+		if (reconnect_response.has_server_info()) {
+			join_resp_.mutable_server_info()->CopyFrom(reconnect_response.server_info());
+		}
+		if (reconnect_response.has_client_configuration()) {
+			join_resp_.mutable_client_configuration()->CopyFrom(
+			    reconnect_response.client_configuration());
+		}
+		if (reconnect_response.ice_servers_size() > 0) {
+			join_resp_.clear_ice_servers();
+			for (const auto& ice_server : reconnect_response.ice_servers()) {
+				join_resp_.add_ice_servers()->CopyFrom(ice_server);
+			}
+		}
+	}
+	if (auto* listener = room_listener_.load()) {
+		listener->SignalResumedEvent();
+	}
+
+	bool restart_publisher = false;
+	{
+		std::lock_guard<std::mutex> guard(rtc_connected_mutex_);
+		rtc_connected_ = false;
+	}
+	publisher_answer_received_ = false;
+	{
+		std::lock_guard<std::mutex> guard(session_lock_);
+		if (!rtc_session_) {
+			return false;
+		}
+		restart_publisher = rtc_session_->ShouldRestartPublisherIce();
+		if (!rtc_session_->RestartPublisherIce()) {
+			return false;
+		}
+	}
+	if (!restart_publisher) {
+		return !recovery_stop_ && !force_full_reconnect_;
+	}
+
+	std::unique_lock<std::mutex> guard(rtc_connected_mutex_);
+	const bool connected = rtc_connected_cv_.wait_for(guard, kRecoveryRtcTimeout, [this]() {
+		if (recovery_stop_.load() || force_full_reconnect_.load()) {
+			return true;
+		}
+		if (!publisher_answer_received_.load()) {
+			return false;
+		}
+		std::lock_guard<std::mutex> session_guard(session_lock_);
+		return rtc_session_ != nullptr && rtc_session_->IsConnected();
+	});
+	return connected && !recovery_stop_ && !force_full_reconnect_;
 }
 
 void RtcEngine::Disconnect() {
@@ -192,14 +301,25 @@ void RtcEngine::StopRecovery() {
 	}
 	recovery_in_progress_ = false;
 	recovering_connection_ = false;
+	force_full_reconnect_ = false;
 }
 
-void RtcEngine::StartRecovery() {
+void RtcEngine::StartRecovery(livekit::DisconnectReason reason, bool force_full_reconnect) {
 	if (!recovery_allowed_ || recovery_stop_) {
 		return;
 	}
+	recovery_failure_reason_ = reason;
+	if (force_full_reconnect) {
+		force_full_reconnect_ = true;
+	}
 	bool expected = false;
 	if (!recovery_in_progress_.compare_exchange_strong(expected, true)) {
+		if (force_full_reconnect) {
+			rtc_connected_cv_.notify_all();
+			if (auto* listener = room_listener_.load()) {
+				listener->ReconnectingEvent(true);
+			}
+		}
 		return;
 	}
 	recovering_connection_ = true;
@@ -208,7 +328,7 @@ void RtcEngine::StartRecovery() {
 		rtc_connected_ = false;
 	}
 	if (auto* listener = room_listener_.load()) {
-		listener->ReconnectingEvent();
+		listener->ReconnectingEvent(force_full_reconnect);
 	}
 
 	std::thread completed_thread;
@@ -236,6 +356,33 @@ void RtcEngine::RunRecovery() {
 	const auto attempts = (std::max)(uint32_t{1}, options.join_retries);
 	livekit::JoinResponse recovered_response;
 	bool recovered = false;
+
+	if (!force_full_reconnect_ && !recovery_stop_) {
+		std::string token;
+		{
+			std::lock_guard<std::mutex> guard(access_token_mutex_);
+			token = access_token_;
+		}
+		if (!url.empty() && !token.empty()) {
+			recovered = ResumeTransport(url, token, options, recovery_failure_reason_.load());
+		}
+		if (recovered && !force_full_reconnect_) {
+			if (auto* listener = room_listener_.load()) {
+				listener->ResumedEvent();
+			}
+			recovering_connection_ = false;
+			recovery_in_progress_ = false;
+			return;
+		}
+	}
+
+	force_full_reconnect_ = true;
+	if (!recovery_stop_) {
+		if (auto* listener = room_listener_.load()) {
+			listener->ReconnectingEvent(true);
+		}
+	}
+	recovered = false;
 
 	for (uint32_t attempt = 0; attempt < attempts && !recovery_stop_; ++attempt) {
 		{
@@ -279,9 +426,10 @@ void RtcEngine::RunRecovery() {
 		ResetTransport(false);
 		recovery_allowed_ = false;
 		if (auto* listener = room_listener_.load()) {
-			listener->SignalDisconnectedEvent();
+			listener->SignalDisconnectedEvent(recovery_failure_reason_.load());
 		}
 	}
+	force_full_reconnect_ = false;
 	recovering_connection_ = false;
 	recovery_in_progress_ = false;
 }
@@ -289,9 +437,15 @@ void RtcEngine::RunRecovery() {
 void RtcEngine::SetRoomObserver(RtcEngineListener* listener) { room_listener_.store(listener); }
 
 void RtcEngine::OnAnswer(std::unique_ptr<webrtc::SessionDescriptionInterface> answer) {
-	std::lock_guard<std::mutex> guard(session_lock_);
-	if (rtc_session_) {
-		rtc_session_->SetPublisherAnswer(std::move(answer));
+	{
+		std::lock_guard<std::mutex> guard(session_lock_);
+		if (rtc_session_) {
+			rtc_session_->SetPublisherAnswer(std::move(answer));
+		}
+	}
+	if (recovering_connection_) {
+		publisher_answer_received_ = true;
+		rtc_connected_cv_.notify_all();
 	}
 	return;
 }
@@ -449,6 +603,41 @@ std::string RtcEngine::AccessTokenForReconnect() const {
 	return access_token_;
 }
 
+void RtcEngine::SendSyncState(
+    const std::vector<livekit::TrackPublishedResponse>& published_tracks) {
+	livekit::SyncState sync;
+	{
+		std::lock_guard<std::mutex> guard(session_lock_);
+		if (!rtc_session_) {
+			return;
+		}
+		rtc_session_->PopulateSyncState(sync);
+	}
+	{
+		std::lock_guard<std::mutex> guard(connection_params_mutex_);
+		sync.mutable_subscription()->set_subscribe(
+		    !connection_options_.signal_options.auto_subscribe);
+	}
+	for (const auto& track : published_tracks) {
+		sync.add_publish_tracks()->CopyFrom(track);
+	}
+	{
+		std::lock_guard<std::mutex> guard(data_channels_lock_);
+		for (const auto& channel : {lossyDC_, reliableDC_}) {
+			if (!channel || channel->id() < 0) {
+				continue;
+			}
+			auto* info = sync.add_data_channels();
+			info->set_label(channel->label());
+			info->set_id(static_cast<uint32_t>(channel->id()));
+			info->set_target(livekit::SignalTarget::PUBLISHER);
+		}
+	}
+	if (auto signal_client = SignalClientSnapshot()) {
+		signal_client->SendSyncState(sync);
+	}
+}
+
 bool RtcEngine::SimulateSignalDisconnectForTesting() {
 	auto signal_client = SignalClientSnapshot();
 	if (!signal_client || !recovery_allowed_) {
@@ -458,15 +647,26 @@ bool RtcEngine::SimulateSignalDisconnectForTesting() {
 	return true;
 }
 
+bool RtcEngine::SimulateFullReconnectForTesting() {
+	if (!recovery_allowed_ || recovery_stop_) {
+		return false;
+	}
+	StartRecovery(livekit::DisconnectReason::SIGNAL_CLOSE, true);
+	return true;
+}
+
 void RtcEngine::OnLeave(const livekit::LeaveRequest leave) {
 	if (leave.action() == livekit::LeaveRequest::DISCONNECT) {
 		recovery_allowed_ = false;
 		if (auto* listener = room_listener_.load()) {
-			listener->SignalDisconnectedEvent();
+			listener->SignalDisconnectedEvent(leave.reason());
 		}
 		return;
 	}
-	StartRecovery();
+	const auto reason = leave.reason() == livekit::DisconnectReason::UNKNOWN_REASON
+	                        ? livekit::DisconnectReason::SIGNAL_CLOSE
+	                        : leave.reason();
+	StartRecovery(reason, leave.action() == livekit::LeaveRequest::RECONNECT);
 }
 
 void RtcEngine::OnLocalTrackPublished(const livekit::TrackPublishedResponse& response) {
@@ -531,10 +731,10 @@ void RtcEngine::OnTrickle(std::string& candidate, livekit::SignalTarget target) 
 }
 void RtcEngine::OnClose() {
 	if (recovery_allowed_ && !recovery_stop_) {
-		StartRecovery();
+		StartRecovery(livekit::DisconnectReason::SIGNAL_CLOSE);
 	} else if (!recovery_in_progress_ && !recovery_stop_) {
 		if (auto* listener = room_listener_.load()) {
-			listener->SignalDisconnectedEvent();
+			listener->SignalDisconnectedEvent(livekit::DisconnectReason::SIGNAL_CLOSE);
 		}
 	}
 }
@@ -591,7 +791,7 @@ void RtcEngine::OnStateChange(RtcSession::State connection_state,
 		}
 	} else if (connection_state == RtcSession::State::kFailed && recovery_allowed_ &&
 	           !recovery_stop_) {
-		StartRecovery();
+		StartRecovery(livekit::DisconnectReason::MEDIA_FAILURE, true);
 	}
 }
 

--- a/src/core/detail/rtc_engine.h
+++ b/src/core/detail/rtc_engine.h
@@ -60,8 +60,10 @@ public:
 		virtual void RoomUpdateEvent(const livekit::Room& update) = 0;
 		virtual void
 		ConnectionQualityEvent(const std::vector<livekit::ConnectionQualityInfo>& updates) = 0;
-		virtual void SignalDisconnectedEvent() = 0;
-		virtual void ReconnectingEvent() = 0;
+		virtual void SignalDisconnectedEvent(livekit::DisconnectReason reason) = 0;
+		virtual void ReconnectingEvent(bool full_reconnect) = 0;
+		virtual void SignalResumedEvent() = 0;
+		virtual void ResumedEvent() = 0;
 		virtual void ReconnectedEvent(livekit::JoinResponse join_resp) = 0;
 	};
 
@@ -92,7 +94,9 @@ public:
 	// Retained internally so connection recovery can authenticate with the newest server-issued
 	// token instead of the token used for the initial join.
 	std::string AccessTokenForReconnect() const;
+	void SendSyncState(const std::vector<livekit::TrackPublishedResponse>& published_tracks);
 	bool SimulateSignalDisconnectForTesting();
+	bool SimulateFullReconnectForTesting();
 
 	/* Pure virtual methods inherited from SignalClientObserver */
 public:
@@ -178,9 +182,11 @@ public:
 private:
 	livekit::JoinResponse ConnectTransport(const std::string& url, const std::string& token,
 	                                       const EngineOptions& options);
+	bool ResumeTransport(const std::string& url, const std::string& token,
+	                     const EngineOptions& options, livekit::DisconnectReason reason);
 	void ResetTransport(bool send_leave);
 	std::shared_ptr<SignalClient> SignalClientSnapshot() const;
-	void StartRecovery();
+	void StartRecovery(livekit::DisconnectReason reason, bool force_full_reconnect = false);
 	void RunRecovery();
 	void StopRecovery();
 	void negotiate();
@@ -218,11 +224,15 @@ private:
 	std::atomic<bool> recovery_stop_{false};
 	std::atomic<bool> recovery_in_progress_{false};
 	std::atomic<bool> recovering_connection_{false};
+	std::atomic<bool> force_full_reconnect_{false};
+	std::atomic<livekit::DisconnectReason> recovery_failure_reason_{
+	    livekit::DisconnectReason::UNKNOWN_REASON};
 	std::mutex recovery_thread_mutex_;
 	std::thread recovery_thread_;
 	std::mutex rtc_connected_mutex_;
 	std::condition_variable rtc_connected_cv_;
 	bool rtc_connected_ = false;
+	std::atomic<bool> publisher_answer_received_{false};
 };
 
 } // namespace core

--- a/src/core/detail/rtc_session.cpp
+++ b/src/core/detail/rtc_session.cpp
@@ -153,6 +153,7 @@ RtcSession::CreateSender(LocalTrack* track, TrackPublishOptions options,
 	auto init = webrtc::RtpTransceiverInit();
 	init.direction = webrtc::RtpTransceiverDirection::kSendOnly;
 	init.send_encodings = send_encodings;
+	is_publisher_connection_required_.store(true);
 	auto transceiver = publisher_pc_->AddTransceiver(track->media_track()->rtc_track(), init);
 	return transceiver;
 }
@@ -213,6 +214,56 @@ void RtcSession::AddIceCandidate(const std::string& candidate, const livekit::Si
 }
 
 bool RtcSession::Negotiate() { return this->publisher_pc_->Negotiate(); }
+
+bool RtcSession::ShouldRestartPublisherIce() const {
+	return is_publisher_connection_required_.load() || has_published_.load();
+}
+
+bool RtcSession::RestartPublisherIce() {
+	if (!ShouldRestartPublisherIce()) {
+		return true;
+	}
+	return publisher_pc_ != nullptr && publisher_pc_->Negotiate(true);
+}
+
+bool RtcSession::IsConnected() const { return state_.load() == State::kConnected; }
+
+bool RtcSession::UpdateConfiguration(const livekit::ReconnectResponse& response) {
+	if (response.ice_servers_size() > 0) {
+		join_response_.clear_ice_servers();
+		for (const auto& ice_server : response.ice_servers()) {
+			join_response_.add_ice_servers()->CopyFrom(ice_server);
+		}
+	}
+	if (response.has_client_configuration()) {
+		join_response_.mutable_client_configuration()->CopyFrom(response.client_configuration());
+	}
+	if (response.has_server_info()) {
+		join_response_.mutable_server_info()->CopyFrom(response.server_info());
+	}
+	const auto config = make_rtc_config_join(join_response_, options_);
+	return publisher_pc_->SetConfiguration(config) && subscriber_pc_->SetConfiguration(config);
+}
+
+void RtcSession::PopulateSyncState(livekit::SyncState& sync) {
+	std::string offer;
+	std::string answer;
+	if (is_subscriber_connection_required_.load()) {
+		offer = subscriber_pc_->GetCurrentRemoteDescription();
+		answer = subscriber_pc_->GetCurrentLocalDescription();
+	} else {
+		offer = publisher_pc_->GetCurrentLocalDescription();
+		answer = publisher_pc_->GetCurrentRemoteDescription();
+	}
+	if (!offer.empty()) {
+		sync.mutable_offer()->set_type("offer");
+		sync.mutable_offer()->set_sdp(std::move(offer));
+	}
+	if (!answer.empty()) {
+		sync.mutable_answer()->set_type("answer");
+		sync.mutable_answer()->set_sdp(std::move(answer));
+	}
+}
 
 webrtc::scoped_refptr<webrtc::DataChannelInterface>
 RtcSession::CreateDataChannel(const std::string& label,

--- a/src/core/detail/rtc_session.h
+++ b/src/core/detail/rtc_session.h
@@ -121,6 +121,11 @@ public:
 	CreateSubscriberAnswerFromOffer(std::unique_ptr<webrtc::SessionDescriptionInterface> offer);
 	void AddIceCandidate(const std::string& candidate, const livekit::SignalTarget target);
 	bool Negotiate();
+	bool ShouldRestartPublisherIce() const;
+	bool RestartPublisherIce();
+	bool IsConnected() const;
+	bool UpdateConfiguration(const livekit::ReconnectResponse& response);
+	void PopulateSyncState(livekit::SyncState& sync);
 	webrtc::scoped_refptr<webrtc::DataChannelInterface>
 	CreateDataChannel(const std::string& label, const webrtc::DataChannelInit* dataChannelDict);
 
@@ -180,8 +185,8 @@ private:
 	std::unique_ptr<PeerTransport> publisher_pc_;
 	std::unique_ptr<PeerTransport> subscriber_pc_;
 	EngineOptions options_;
-	bool is_publisher_connection_required_;
-	bool is_subscriber_connection_required_;
+	std::atomic<bool> is_publisher_connection_required_;
+	std::atomic<bool> is_subscriber_connection_required_;
 	std::atomic<State> state_ = State::kNew;
 	std::atomic<bool> has_published_ = false;
 	std::unique_ptr<Debouncer> publisher_negotiation_debouncer_ = nullptr;

--- a/src/core/detail/signal_client.cpp
+++ b/src/core/detail/signal_client.cpp
@@ -142,6 +142,37 @@ livekit::JoinResponse SignalClient::Connect() {
 	return livekit::JoinResponse();
 }
 
+bool SignalClient::Resume() {
+	{
+		std::lock_guard<std::mutex> guard(lock_);
+		if (resume_resolved_) {
+			resume_promise_ = std::promise<bool>();
+			resume_resolved_ = false;
+		}
+		state_ = SignalConnectionState::RECONNECTING;
+	}
+
+	auto future = resume_promise_.get_future();
+	wsc_->connect();
+	wsc_->service();
+	try {
+		return future.get();
+	} catch (const std::exception& e) {
+		std::cerr << "Signal resume error: " << e.what() << std::endl;
+	}
+	return false;
+}
+
+void SignalClient::SetPingConfig(int timeout_seconds, int interval_seconds) {
+	ping_timeout_duration_ = timeout_seconds;
+	ping_interval_duration_ = interval_seconds;
+}
+
+livekit::ReconnectResponse SignalClient::ReconnectResponseSnapshot() const {
+	std::lock_guard<std::mutex> guard(lock_);
+	return reconnect_response_;
+}
+
 void SignalClient::Close(bool update_state) {
 	if (update_state) {
 		state_ = SignalConnectionState::DISCONNECTING;
@@ -372,7 +403,12 @@ void SignalClient::handleWsBinaryMessage(const WebsocketData& data) {
 				break;
 			case livekit::SignalResponse::MessageCase::kLeave:
 				if (isEstablishingConnection()) {
-					resolveJoinResponse(livekit::JoinResponse());
+					if (state_ == SignalConnectionState::RECONNECTING) {
+						resolveResume(false);
+					} else {
+						resolveJoinResponse(livekit::JoinResponse());
+					}
+					should_process_message = true;
 				}
 				break;
 			default:
@@ -380,9 +416,10 @@ void SignalClient::handleWsBinaryMessage(const WebsocketData& data) {
 					state_ = SignalConnectionState::CONNECTED;
 					this->startPingInterval();
 					if (resp.message_case() == livekit::SignalResponse::MessageCase::kReconnect) {
-						resolveJoinResponse(resp.join());
+						reconnect_response_.CopyFrom(resp.reconnect());
+						resolveResume(true);
 					} else {
-						resolveJoinResponse(livekit::JoinResponse());
+						resolveResume(false);
 						should_process_message = true;
 					}
 				} else if (!option_.reconnect) {
@@ -606,7 +643,11 @@ void SignalClient::handleOnClose(std::string reason) {
 		notify_observer = previous_state != SignalConnectionState::DISCONNECTED;
 		if (previous_state == SignalConnectionState::CONNECTING ||
 		    previous_state == SignalConnectionState::RECONNECTING) {
-			resolveJoinResponse(livekit::JoinResponse());
+			if (previous_state == SignalConnectionState::RECONNECTING) {
+				resolveResume(false);
+			} else {
+				resolveJoinResponse(livekit::JoinResponse());
+			}
 		}
 		observer = observer_;
 	}
@@ -623,6 +664,14 @@ void SignalClient::resolveJoinResponse(const livekit::JoinResponse& response) {
 	}
 	join_response_resolved_ = true;
 	promise_.set_value(response);
+}
+
+void SignalClient::resolveResume(bool connected) {
+	if (resume_resolved_) {
+		return;
+	}
+	resume_resolved_ = true;
+	resume_promise_.set_value(connected);
 }
 
 void SignalClient::resetPingTimeout() {

--- a/src/core/detail/signal_client.h
+++ b/src/core/detail/signal_client.h
@@ -101,6 +101,9 @@ public:
 	~SignalClient();
 
 	livekit::JoinResponse Connect();
+	bool Resume();
+	void SetPingConfig(int timeout_seconds, int interval_seconds);
+	livekit::ReconnectResponse ReconnectResponseSnapshot() const;
 
 	void AddObserver(SignalClientObserver* observer);
 	void RemoveObserver();
@@ -156,6 +159,7 @@ private:
 	void clearPingInterval();
 	void handleOnClose(std::string reason);
 	void resolveJoinResponse(const livekit::JoinResponse& response);
+	void resolveResume(bool connected);
 	uint64_t getNextRequestId();
 
 	int64_t rtt() const;
@@ -169,6 +173,9 @@ private:
 	std::atomic<SignalConnectionState> state_;
 	std::promise<livekit::JoinResponse> promise_;
 	bool join_response_resolved_ = false;
+	std::promise<bool> resume_promise_;
+	bool resume_resolved_ = false;
+	livekit::ReconnectResponse reconnect_response_;
 	int ping_timeout_duration_ = 0;
 	int ping_interval_duration_ = 0;
 	mutable std::mutex ping_timeout_timer_lock_;
@@ -178,7 +185,7 @@ private:
 	std::shared_ptr<Timer> ping_interval_timer_ = nullptr;
 	SignalClientObserver* observer_ = nullptr;
 	std::atomic<int64_t> rtt_;
-	std::atomic<uint64_t> request_id_;
+	std::atomic<uint64_t> request_id_{0};
 };
 
 } // namespace core

--- a/src/core/detail/signal_url.cpp
+++ b/src/core/detail/signal_url.cpp
@@ -38,15 +38,18 @@ std::string BuildSignalUrl(const std::string& url, const std::string& token,
 	SetParameter(request, "auto_subscribe", options.auto_subscribe ? "1" : "0");
 	SetParameter(request, "sdk",
 	             options.sdk_options.sdk.empty() ? kDefaultSdk : options.sdk_options.sdk);
-	SetParameter(request, "version", options.sdk_options.sdk_version.empty()
-	                                     ? kDefaultSdkVersion
-	                                     : options.sdk_options.sdk_version);
+	SetParameter(request, "version",
+	             options.sdk_options.sdk_version.empty() ? kDefaultSdkVersion
+	                                                     : options.sdk_options.sdk_version);
 	SetParameter(request, "protocol", kProtocolVersion);
 	if (options.adaptive_stream) {
 		SetParameter(request, "adaptive_stream", "1");
 	}
 	if (options.reconnect) {
 		SetParameter(request, "reconnect", "1");
+		if (!options.participant_sid.empty()) {
+			SetParameter(request, "sid", options.participant_sid);
+		}
 		if (options.reconnect_reason != 0) {
 			SetParameter(request, "reconnect_reason", std::to_string(options.reconnect_reason));
 		}

--- a/src/core/room.cpp
+++ b/src/core/room.cpp
@@ -63,6 +63,15 @@ from_connection_quality(livekit::ConnectionQuality quality) {
 		return livekit::core::ConnectionQuality::Unknown;
 	}
 }
+
+static livekit::core::DisconnectReason from_disconnect_reason(livekit::DisconnectReason reason) {
+	const auto value = static_cast<int>(reason);
+	if (value < static_cast<int>(livekit::DisconnectReason::UNKNOWN_REASON) ||
+	    value > static_cast<int>(livekit::DisconnectReason::AGENT_ERROR)) {
+		return livekit::core::DisconnectReason::Unknown;
+	}
+	return static_cast<livekit::core::DisconnectReason>(value);
+}
 } // namespace
 
 namespace livekit {
@@ -97,6 +106,8 @@ bool Room::Connect(std::string url, std::string token, RoomConnectOptions opts) 
 		return false;
 	}
 	disconnected_event_emitted_ = false;
+	full_reconnect_prepared_ = false;
+	disconnect_reason_ = DisconnectReason::Unknown;
 
 	try {
 		EngineOptions engine_options = make_engine_config(opts);
@@ -104,11 +115,13 @@ bool Room::Connect(std::string url, std::string token, RoomConnectOptions opts) 
 		if (!join_response.has_room()) {
 			rtc_engine_->Disconnect();
 			state_ = RoomState::Failed;
+			disconnect_reason_ = DisconnectReason::JoinFailure;
 			return false;
 		}
 		ApplyJoinResponse(join_response, false);
 	} catch (...) {
 		state_ = RoomState::Failed;
+		disconnect_reason_ = DisconnectReason::JoinFailure;
 		throw;
 	}
 
@@ -128,6 +141,8 @@ void Room::RemoveEventListener() {
 bool Room::IsConnected() { return state_.load() == RoomState::Connected; }
 
 RoomInterface::RoomState Room::State() const { return state_.load(); }
+
+DisconnectReason Room::LastDisconnectReason() const { return disconnect_reason_.load(); }
 
 std::string Room::Sid() {
 	std::lock_guard<std::mutex> guard(room_info_mutex_);
@@ -171,7 +186,7 @@ bool Room::Disconnect() {
 		incoming_texts_.clear();
 	}
 	state_ = RoomState::Disconnected;
-	NotifyDisconnectedOnce();
+	NotifyDisconnectedOnce(DisconnectReason::ClientInitiated);
 	return true;
 }
 
@@ -276,6 +291,10 @@ bool Room::SimulateSignalDisconnectForTesting() {
 	return rtc_engine_ != nullptr && rtc_engine_->SimulateSignalDisconnectForTesting();
 }
 
+bool Room::SimulateFullReconnectForTesting() {
+	return rtc_engine_ != nullptr && rtc_engine_->SimulateFullReconnectForTesting();
+}
+
 RoomInterface::RoomState RoomInterface::State() const {
 	auto* room = dynamic_cast<const Room*>(this);
 	if (room != nullptr) {
@@ -283,6 +302,11 @@ RoomInterface::RoomState RoomInterface::State() const {
 	}
 	return const_cast<RoomInterface*>(this)->IsConnected() ? RoomState::Connected
 	                                                       : RoomState::Disconnected;
+}
+
+DisconnectReason RoomInterface::LastDisconnectReason() const {
+	auto* room = dynamic_cast<const Room*>(this);
+	return room != nullptr ? room->LastDisconnectReason() : DisconnectReason::Unknown;
 }
 
 RemoteParticipantInterface* RoomInterface::GetRemoteParticipantByIdentity(std::string identity) {
@@ -321,14 +345,44 @@ void Room::ConnectedEvent(livekit::JoinResponse join_resp) {
 	}
 }
 
-void Room::ReconnectingEvent() {
+void Room::ReconnectingEvent(bool full_reconnect) {
+	if (full_reconnect && !full_reconnect_prepared_.exchange(true)) {
+		local_participant_->DetachTrackTransceiversForReconnect();
+	}
 	auto expected = RoomState::Connected;
 	if (!state_.compare_exchange_strong(expected, RoomState::Reconnecting)) {
 		return;
 	}
-	local_participant_->DetachTrackTransceiversForReconnect();
 	if (auto* listener = event_listener_.load()) {
 		listener->OnReconnecting();
+	}
+}
+
+void Room::SignalResumedEvent() {
+	std::vector<livekit::TrackPublishedResponse> published_tracks;
+	for (auto* publication : local_participant_->GetTrackPublications()) {
+		auto* local_publication = dynamic_cast<LocalTrackPublication*>(publication);
+		auto* local_track = local_publication != nullptr
+		                        ? dynamic_cast<LocalTrack*>(local_publication->Track())
+		                        : nullptr;
+		if (local_track == nullptr || local_track->media_track() == nullptr ||
+		    local_track->media_track()->rtc_track() == nullptr) {
+			continue;
+		}
+		auto* response = &published_tracks.emplace_back();
+		response->set_cid(local_track->media_track()->rtc_track()->id());
+		response->mutable_track()->CopyFrom(local_publication->Info());
+	}
+	rtc_engine_->SendSyncState(published_tracks);
+}
+
+void Room::ResumedEvent() {
+	if (state_.load() != RoomState::Reconnecting) {
+		return;
+	}
+	state_ = RoomState::Connected;
+	if (auto* listener = event_listener_.load()) {
+		listener->OnReconnected();
 	}
 }
 
@@ -338,13 +392,14 @@ void Room::ReconnectedEvent(livekit::JoinResponse join_resp) {
 	}
 	ApplyJoinResponse(join_resp, true);
 	local_participant_->RepublishAllTracksAfterReconnect();
+	full_reconnect_prepared_ = false;
 	state_ = RoomState::Connected;
 	if (auto* listener = event_listener_.load()) {
 		listener->OnReconnected();
 	}
 }
 
-void Room::SignalDisconnectedEvent() {
+void Room::SignalDisconnectedEvent(livekit::DisconnectReason reason) {
 	auto current = state_.load();
 	while (current != RoomState::Disconnecting && current != RoomState::Disconnected &&
 	       current != RoomState::Failed) {
@@ -353,14 +408,15 @@ void Room::SignalDisconnectedEvent() {
 		}
 	}
 	if (current != RoomState::Disconnecting && current != RoomState::Disconnected) {
-		NotifyDisconnectedOnce();
+		NotifyDisconnectedOnce(from_disconnect_reason(reason));
 	}
 }
 
-void Room::NotifyDisconnectedOnce() {
+void Room::NotifyDisconnectedOnce(DisconnectReason reason) {
 	if (!disconnected_event_emitted_.exchange(true)) {
+		disconnect_reason_ = reason;
 		if (auto* listener = event_listener_.load()) {
-			listener->OnDisconnected();
+			listener->OnDisconnected(reason);
 		}
 	}
 }

--- a/src/core/room.h
+++ b/src/core/room.h
@@ -47,6 +47,7 @@ public:
 	virtual void AddEventListener(RoomEventInterface* listener) override;
 	virtual void RemoveEventListener() override;
 	RoomState State() const;
+	DisconnectReason LastDisconnectReason() const;
 	virtual bool IsConnected() override;
 	virtual bool Disconnect() override;
 	std::string Sid() override;
@@ -64,6 +65,7 @@ public:
 	bool SetRemoteTrackSubscribedInternal(std::string participant_sid, std::string track_sid,
 	                                      bool subscribed);
 	bool SimulateSignalDisconnectForTesting();
+	bool SimulateFullReconnectForTesting();
 
 	/* Pure virtual methods inherited from RtcEngineListener */
 public:
@@ -78,8 +80,10 @@ public:
 	void RoomUpdateEvent(const livekit::Room& update) override;
 	void
 	ConnectionQualityEvent(const std::vector<livekit::ConnectionQualityInfo>& updates) override;
-	void SignalDisconnectedEvent() override;
-	void ReconnectingEvent() override;
+	void SignalDisconnectedEvent(livekit::DisconnectReason reason) override;
+	void ReconnectingEvent(bool full_reconnect) override;
+	void SignalResumedEvent() override;
+	void ResumedEvent() override;
 	void ReconnectedEvent(livekit::JoinResponse join_resp) override;
 
 private:
@@ -91,7 +95,7 @@ private:
 	                      const AudioFrame& frame);
 	void NotifyVideoFrame(const std::string& participant_sid, const std::string& track_sid,
 	                      const VideoFrame& frame);
-	void NotifyDisconnectedOnce();
+	void NotifyDisconnectedOnce(DisconnectReason reason);
 
 	struct IncomingFile {
 		FileReceivedEvent event;
@@ -107,6 +111,8 @@ private:
 	RoomOptions options_;
 	std::atomic<RoomState> state_{RoomState::Disconnected};
 	std::atomic<bool> disconnected_event_emitted_{false};
+	std::atomic<bool> full_reconnect_prepared_{false};
+	std::atomic<DisconnectReason> disconnect_reason_{DisconnectReason::Unknown};
 	std::unique_ptr<RtcEngine> rtc_engine_ = nullptr;
 	std::unique_ptr<LocalParticipant> local_participant_ = nullptr;
 	mutable std::mutex participants_mutex_;

--- a/src/core/track/track_publication.cpp
+++ b/src/core/track/track_publication.cpp
@@ -83,6 +83,11 @@ void TrackPublication::UpdateInfo(livekit::TrackInfo info) {
 	muted_ = info_.muted();
 }
 
+livekit::TrackInfo TrackPublication::Info() const {
+	std::lock_guard<std::mutex> guard(mutex_);
+	return info_;
+}
+
 void TrackPublication::SetTrack(::livekit::core::Track* track) {
 	std::lock_guard<std::mutex> guard(mutex_);
 	track_ = track;

--- a/src/core/track/track_publication.h
+++ b/src/core/track/track_publication.h
@@ -46,6 +46,7 @@ public:
 	TrackInterface* Track() override;
 
 	void UpdateInfo(livekit::TrackInfo info);
+	livekit::TrackInfo Info() const;
 	void SetTrack(::livekit::core::Track* track);
 	void SetMuted(bool muted);
 

--- a/test/functional/c_api_test.cpp
+++ b/test/functional/c_api_test.cpp
@@ -72,6 +72,7 @@ TEST(CApiTest, CreatesRoomAndCapturesLocalFrames) {
 	ASSERT_EQ(lk_room_create(&room), LK_STATUS_OK) << lk_last_error();
 	ASSERT_NE(room, nullptr);
 	EXPECT_EQ(lk_room_state(room), LK_ROOM_STATE_DISCONNECTED);
+	EXPECT_EQ(lk_room_disconnect_reason(room), LK_DISCONNECT_REASON_UNKNOWN);
 	EXPECT_FALSE(lk_room_is_connected(room));
 	EXPECT_EQ(lk_room_sid(room, nullptr, 0), 1u);
 
@@ -79,6 +80,7 @@ TEST(CApiTest, CreatesRoomAndCapturesLocalFrames) {
 	lk_room_callbacks_init(&callbacks);
 	EXPECT_EQ(callbacks.on_reconnecting, nullptr);
 	EXPECT_EQ(callbacks.on_reconnected, nullptr);
+	EXPECT_EQ(callbacks.on_disconnected_with_reason, nullptr);
 	EXPECT_EQ(callbacks.on_local_track_published, nullptr);
 	EXPECT_EQ(callbacks.on_local_track_unpublished, nullptr);
 	EXPECT_EQ(callbacks.on_text_received, nullptr);

--- a/test/functional/participant_state_test.cpp
+++ b/test/functional/participant_state_test.cpp
@@ -172,6 +172,18 @@ public:
 	int disconnected_count = 0;
 };
 
+class DetailedConnectionEvents final : public RoomEventInterface {
+public:
+	void OnConnected() override {}
+	void OnDisconnected(DisconnectReason reason) override {
+		++disconnected_count;
+		disconnect_reason = reason;
+	}
+
+	int disconnected_count = 0;
+	DisconnectReason disconnect_reason = DisconnectReason::Unknown;
+};
+
 TEST(RoomConnectionStateTest, TransitionsThroughSuccessfulReconnect) {
 	Room room;
 	ConnectionEvents events;
@@ -179,23 +191,18 @@ TEST(RoomConnectionStateTest, TransitionsThroughSuccessfulReconnect) {
 	room.ConnectedEvent({});
 	ASSERT_EQ(room.State(), RoomInterface::RoomState::Connected);
 
-	room.ReconnectingEvent();
+	room.ReconnectingEvent(false);
 	EXPECT_EQ(room.State(), RoomInterface::RoomState::Reconnecting);
 	EXPECT_FALSE(room.IsConnected());
 	EXPECT_EQ(events.reconnecting_count, 1);
 
-	livekit::JoinResponse response;
-	response.mutable_room()->set_sid("RM_reconnected");
-	response.mutable_room()->set_name("reconnected-room");
-	response.mutable_participant()->set_sid("PA_local");
-	response.mutable_participant()->set_identity("local");
-	room.ReconnectedEvent(response);
+	room.ResumedEvent();
 	EXPECT_EQ(room.State(), RoomInterface::RoomState::Connected);
 	EXPECT_TRUE(room.IsConnected());
-	EXPECT_EQ(room.Sid(), "RM_reconnected");
 	EXPECT_EQ(events.reconnected_count, 1);
 
 	EXPECT_TRUE(room.Disconnect());
+	EXPECT_EQ(room.LastDisconnectReason(), DisconnectReason::ClientInitiated);
 	room.RemoveEventListener();
 }
 
@@ -206,16 +213,34 @@ TEST(RoomConnectionStateTest, ReportsUnexpectedSignalCloseOnlyOnce) {
 	room.ConnectedEvent({});
 	ASSERT_EQ(room.State(), RoomInterface::RoomState::Connected);
 
-	room.SignalDisconnectedEvent();
+	room.SignalDisconnectedEvent(livekit::DisconnectReason::SIGNAL_CLOSE);
 	EXPECT_EQ(room.State(), RoomInterface::RoomState::Failed);
 	EXPECT_FALSE(room.IsConnected());
 	EXPECT_EQ(events.disconnected_count, 1);
+	EXPECT_EQ(room.LastDisconnectReason(), DisconnectReason::SignalClose);
 
-	room.SignalDisconnectedEvent();
+	room.SignalDisconnectedEvent(livekit::DisconnectReason::SIGNAL_CLOSE);
 	EXPECT_EQ(events.disconnected_count, 1);
 	EXPECT_TRUE(room.Disconnect());
 	EXPECT_EQ(room.State(), RoomInterface::RoomState::Disconnected);
 	EXPECT_EQ(events.disconnected_count, 1);
+	room.RemoveEventListener();
+}
+
+TEST(RoomConnectionStateTest, PreservesDetailedServerDisconnectReason) {
+	Room room;
+	DetailedConnectionEvents events;
+	room.AddEventListener(&events);
+	room.ConnectedEvent({});
+
+	room.SignalDisconnectedEvent(livekit::DisconnectReason::PARTICIPANT_REMOVED);
+	EXPECT_EQ(room.State(), RoomInterface::RoomState::Failed);
+	EXPECT_EQ(room.LastDisconnectReason(), DisconnectReason::ParticipantRemoved);
+	EXPECT_EQ(events.disconnected_count, 1);
+	EXPECT_EQ(events.disconnect_reason, DisconnectReason::ParticipantRemoved);
+
+	EXPECT_TRUE(room.Disconnect());
+	EXPECT_EQ(room.LastDisconnectReason(), DisconnectReason::ParticipantRemoved);
 	room.RemoveEventListener();
 }
 

--- a/test/integration/livekit_server_test.cpp
+++ b/test/integration/livekit_server_test.cpp
@@ -387,7 +387,7 @@ TEST(LiveKitServerTest, RepublishesAudioAfterReconnect) {
 
 	auto* concrete_sender = dynamic_cast<Room*>(sender.get());
 	ASSERT_NE(concrete_sender, nullptr);
-	ASSERT_TRUE(concrete_sender->SimulateSignalDisconnectForTesting());
+	ASSERT_TRUE(concrete_sender->SimulateFullReconnectForTesting());
 	ASSERT_TRUE(WaitUntil([&] { return events.reconnecting(); }, std::chrono::seconds(10)));
 	ASSERT_TRUE(WaitUntil([&] { return events.reconnected() && sender->IsConnected(); },
 	                      std::chrono::seconds(30)));
@@ -453,6 +453,35 @@ TEST(LiveKitServerTest, RepublishesAudioAfterReconnect) {
 	ASSERT_TRUE(WaitUntil(
 	    [&] { return events.received_data("receiver-recovered", receiver_recovered_data, true); }));
 
+	const auto reconnecting_before_sender_resume = events.reconnecting_count();
+	const auto reconnected_before_sender_resume = events.reconnected_count();
+	const auto published_before_sender_resume = events.local_tracks_published();
+	const auto frames_before_sender_resume = events.audio_frame_count();
+	ASSERT_TRUE(concrete_sender->SimulateSignalDisconnectForTesting());
+	ASSERT_TRUE(
+	    WaitUntil([&] { return events.reconnecting_count() > reconnecting_before_sender_resume; },
+	              std::chrono::seconds(10)));
+	ASSERT_TRUE(WaitUntil(
+	    [&] {
+		    return events.reconnected_count() > reconnected_before_sender_resume &&
+		           sender->IsConnected();
+	    },
+	    std::chrono::seconds(30)));
+	EXPECT_EQ(events.local_tracks_published(), published_before_sender_resume);
+	const auto sender_resumed_deadline =
+	    std::chrono::steady_clock::now() + std::chrono::seconds(10);
+	while (events.audio_frame_count() < frames_before_sender_resume + 3 &&
+	       std::chrono::steady_clock::now() < sender_resumed_deadline) {
+		ASSERT_TRUE(audio_source->CaptureFrame(samples.data(), 48000, 1, 480));
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	}
+	EXPECT_GE(events.audio_frame_count(), frames_before_sender_resume + 3);
+	const std::vector<uint8_t> sender_resumed_data{9, 7, 5, 3};
+	data_options.topic = "publisher-resumed";
+	ASSERT_TRUE(sender->GetLocalParticipant()->PublishData(sender_resumed_data, data_options));
+	ASSERT_TRUE(WaitUntil(
+	    [&] { return events.received_data("publisher-resumed", sender_resumed_data, true); }));
+
 	EXPECT_TRUE(sender->GetLocalParticipant()->UnpublishTrack(audio_track.get()));
 	audio_track.reset();
 	audio_source.reset();
@@ -492,7 +521,13 @@ TEST(LiveKitServerTest, SynchronizesParticipantJoinAndLeave) {
 	ASSERT_FALSE(first_local->Sid().empty());
 	ASSERT_FALSE(second_local->Sid().empty());
 	ASSERT_NE(first_local->Identity(), second_local->Identity());
-	ASSERT_TRUE(WaitUntil([&] { return events.connected(second_local->Identity()); }));
+	// A preceding integration process may still be inside LiveKit's reconnect grace period for the
+	// same token identity. In that case the server reconciles the existing participant instead of
+	// emitting a second joined transition, but the room snapshot must still converge.
+	ASSERT_TRUE(WaitUntil([&] {
+		return events.connected(second_local->Identity()) ||
+		       first_room->GetRemoteParticipantByIdentity(second_local->Identity()) != nullptr;
+	}));
 
 	ASSERT_TRUE(WaitUntil(
 	    [&] { return first_room->GetRemoteParticipantBySid(second_local->Sid()) != nullptr; }));

--- a/test/unit/core_utils/signal_url_test.cpp
+++ b/test/unit/core_utils/signal_url_test.cpp
@@ -12,6 +12,7 @@ TEST(SignalUrlTest, AppliesConfiguredConnectionParameters) {
 	options.adaptive_stream = true;
 	options.reconnect = true;
 	options.reconnect_reason = 3;
+	options.participant_sid = "PA_test+sid";
 	options.sdk_options.sdk = "cpp test";
 	options.sdk_options.sdk_version = "1.2.3+dev";
 
@@ -27,6 +28,7 @@ TEST(SignalUrlTest, AppliesConfiguredConnectionParameters) {
 	EXPECT_EQ(parameters.at("adaptive_stream"), "1");
 	EXPECT_EQ(parameters.at("reconnect"), "1");
 	EXPECT_EQ(parameters.at("reconnect_reason"), "3");
+	EXPECT_EQ(parameters.at("sid"), "PA_test%2Bsid");
 	EXPECT_EQ(parameters.at("sdk"), "cpp%20test");
 	EXPECT_EQ(parameters.at("version"), "1.2.3%2Bdev");
 	EXPECT_EQ(parameters.at("protocol"), "15");
@@ -42,6 +44,7 @@ TEST(SignalUrlTest, OmitsDisabledOptionalParametersAndUsesSdkDefaults) {
 	EXPECT_FALSE(parameters.contains("adaptive_stream"));
 	EXPECT_FALSE(parameters.contains("reconnect"));
 	EXPECT_FALSE(parameters.contains("reconnect_reason"));
+	EXPECT_FALSE(parameters.contains("sid"));
 }
 
 } // namespace


### PR DESCRIPTION
Add protocol-level signal resume with SyncState and publisher ICE restart, while retaining automatic full-reconnect fallback. Preserve server disconnect reasons across the C++ and C APIs and cover both recovery paths against a real LiveKit server.